### PR TITLE
added animal's don't speak to final instructions

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0800_direct_narration.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0800_direct_narration.prompt
@@ -1,3 +1,4 @@
 {% if triggeringEvent and triggeringEvent.type == "direct_narration" %}
 This event just happened and must be responded to, no matter what: `{{ triggeringEvent.data }}`. This event is completely factual.
 {% endif %}
+Animals do not speak in words, only making animals sounds. 


### PR DESCRIPTION
If an animal happened to be involved in an narrated event, it can be selected as the speaker.
This addition has it respond as an animal, not a person. 