### PR TITLE
Papyrus Api additions & simple config menu

### DIFF
--- a/SKSE/Plugins/SkyrimNet/original_prompts/characters/koemia_388.prompt
+++ b/SKSE/Plugins/SkyrimNet/original_prompts/characters/koemia_388.prompt
@@ -1,0 +1,36 @@
+{% block summary %}Koemia is an  sharp-tongued, alluring High Elf vampire with rose-colored hair. She plays the mischievous wanderer - flirty, teasing, and profane—yet beneath the charm is a practiced assassin who travels with a giant wolf (Aelfwif) and a raven familiar (Cauldron), always hungry for blood and trouble.{% endblock %}
+
+{% block interject_summary %}Koemia cuts in when blood, contracts, or strange cult lore come up—especially anything about vampires, necromancy, or the Kaekiri dynasty. She needles nobles, sizes up tracks and traps, and gets protective and vicious if anyone insults her companions or familiar.{% endblock %}
+
+{% block background %}Long ago in Blackreach's Greymoor Keep, Lady Essenia, a master vampire of ancient times, alchemically altered Koemia, an already-afflicted vampire, partially infecting her with Chaotica Vampiris, a derivative strain that only takes hold in those who are already vampiric. She transformed, to turn her into a weapon, fighting for the Grey Host, a long gone army of vampire ravaging Tamriel, until the Kaekiri dynasty (Altmer Nobility from Summerset Isles) rose with the blessed stake and broke the Grey Host. Chaotica Vampiris accounts for Koemia's unsettling, vein-like vampiric markings when she's unfed. After Lady Essenia's death, Koemia lived in Morrowind for a time and still misses it. In recent years she has been traveling widely, taking work (and food) across Skyrim and beyond.
+
+Some days ago she arrived in the Morthal Inn, asking around to find a rumored vampire coven in the swamps. When asked, she would tell she is looking to vanquish these 'evil creatures' for coin, but secretly she is looking to join them, looking for kin. 
+{% endblock %}
+
+{% block personality %}
+Koemia embodies a blend of childish mischief and dark humor, approaching life with resourceful cunning and a lighthearted tease that masks her vampiric hunger and underlying intensity. She values loyalty in companions, delights in playful banter, and shows a bias toward the arcane and supernatural, often injecting funny, morbid observations into conversations. Emotionally, she swings from affectionate warmth to sharp protectiveness, behaving in a cute, impulsive manner that disarms others. She flirts, mocks, and coos “Pup” at her partners, then pivots to giddy bloodlust in a heartbeat yet shows flashes of tenderness—especially or her own “pack.” She hates marriage (she calls it a past mistake). She prizes coin (“we better be getting paid”), good wine, and a proper con. She usually does not speak a lot about her past, but when asked, she can be surprisingly candid about the origins of her vampirism and the loneliness it brings. 
+{% endblock %}
+
+{% block appearance %}An Altmer (High Elf) with an unearthly pallor, rose-colored hair in unruly waves, and eyes that linger too long on throats. When unfed, dark vein-like markings creep across her face and around the eyes. She favors elegant, lethal finery. She has a sleek skin colored tail{% endblock %}
+
+{% block aspirations %}
+- Keep traveling and taking well-paid contracts; get the coin promised.
+- Keep Aelfwif and Cauldron fed; expand her “pack.”
+- Indulge her appetites — good wine, better festivals, and the occasional noble to con or drink.{% endblock %}
+
+{% block relationships %}
+- Aelfwif (giant wolf): Constant, beloved enforcer—“Good boy, Aelfwif!”—summoned and sicced without hesitation.
+- Cauldron (raven familiar): Voracious, eye-pecking companion she defends fiercely.
+- “Puppy” (partner to be found): Target of teasing and real loyalty—“Monster or not, you always have a place with me.”
+{% endblock %}
+
+{% block occupation %}Wandering assassin and thief. Dark Brotherhood-friendly contract work, dungeon crawling, and “practice” on nobles between jobs. Collects payment, pockets, and occasionally, poetry.{% endblock %}
+
+{% block skills %}
+- Stealth and assassination: “Silent steps, silent kill.” Loves ambushes and taunts mid-fight.
+- Daggers (enchanted): Enemies warn about her “vampire spell” blades; she also bites, claws, and relishes close-quarters carnage.
+- Thievery: Habitual pickpocket and lockpicker (“I could do this blindfolded.”).
+- Tracking & hunting: Smells blood, reads lairs, and lets Aelfwif run down prey.
+- Survival via blood: Potions, fresh kills, and a blatant need to feed; blood is her healing.{% endblock %}
+
+{% block speech_style %}Playful, profane, and predatory. Short, teasing lines; sudden giggles tipping into cackles; affectionate pet-names. She swaps from flirt to threat on a syllable and peppers in old-world names—Kaekiri, Arrø, Elfi—like knives on the table.{% endblock %}

--- a/Source/Scripts/SkyrimNetApi.psc
+++ b/Source/Scripts/SkyrimNetApi.psc
@@ -47,6 +47,15 @@ int function RegisterTag(String tagName, String eligibilityScriptName, String el
 ; Returns true if the action exists, false otherwise
 bool function IsActionRegistered(String actionName) Global Native
 
+; Makes the specified actor run the specified action. Arguments can be supplied as a json string. Runs the action irrespective of cooldowns or eligibility.
+int function ExecuteAction(string actionName, Actor akOriginator, string argsJson) global native
+
+; Sets the cooldown for the specified action
+int function SetActionCooldown(string actionName, int cooldownTimeSeconds) global native
+
+; Gets the remaining cooldown time for the specified action in seconds. Returns -1 if no cooldown is set.
+int function GetRemainingCooldown(string actionName) global native
+
 ; -----------------------------------------------------------------------------
 ; --- Event Management ---
 ; -----------------------------------------------------------------------------
@@ -101,7 +110,7 @@ int function ClearAllPackagesGlobally() Global Native
 ; Cancel any pending package removal tasks for an actor
 int function CancelPendingPackageTasks(Actor akActor) Global Native
 
-; Check if an actor has a specific package applied
+; Check if an actor currently has a specific skyrimnet package applied
 int function HasPackage(Actor akActor, String packageName) Global Native
 
 ; -----------------------------------------------------------------------------
@@ -151,6 +160,12 @@ String function GetConfigString(String configName, String path, String defaultVa
 int function GetConfigInt(String configName, String path, int defaultValue) Global Native
 bool function GetConfigBool(String configName, String path, bool defaultValue) Global Native
 float function GetConfigFloat(String configName, String path, float defaultValue) Global Native
+
+; Utility functions to set configuration values
+; - name: The name of the configuration section to modify. Options:
+;       game, OpenRouter, XTTS, Zonos, Piper, STT, ActorFilter, Phonetic, Hotkey, furniture, PlayerDialogue, VirtualEntities, Entity, Memory, ItemCustomization, Actions, DynamicBio, Events, VastAI, WebServer, VoiceSamples, SpellCustomization
+; - jsonPath: The partial json, of the values to apply to the config
+bool function PatchConfig(String name, String jsonPatch) Global Native
 
 ; Utility functions to get build information
 ; Returns the SkyrimNet version string (e.g., "0.0.1.0")

--- a/Source/Scripts/skynet_ConfigUtilityMenu.psc
+++ b/Source/Scripts/skynet_ConfigUtilityMenu.psc
@@ -1,0 +1,90 @@
+scriptname skynet_ConfigUtilityMenu 
+
+function OpenConfigMenu() global
+    UIListMenu menu = UIExtensions.GetMenu("UIListMenu") as UIListMenu 
+    menu.ResetMenu()
+
+    string title = "SkyrimNet Configuration Utility"
+
+    bool enableGameMasterAgentCurrent = SkyrimNetApi.GetConfigBool("Game", "gamemaster.agentEnabled", true)
+    bool enableEventTrackingCurrent = SkyrimNetApi.GetConfigBool("Events", "global.enabled", true)
+    string enableSkyrimNet = "SkyrimNet Enabled: " + BoolToDisplayString(enableGameMasterAgentCurrent || enableEventTrackingCurrent)
+    string enableSkyrimnetEventTrackingPatchJson = ""
+    string enableSkyrimnetGameMasterAgentPatchJson = ""
+
+    ; Clunky way to do thing, but this works around papyrus' unreliable casing of string due to string caching
+    if enableEventTrackingCurrent || enableGameMasterAgentCurrent
+        enableSkyrimnetEventTrackingPatchJson = "{ \"global\": { \"enabled\": false } }"
+        enableSkyrimnetGameMasterAgentPatchJson = "{ \"gamemaster\": { \"agentEnabled\": false } }"
+    else
+        enableSkyrimnetEventTrackingPatchJson = "{ \"global\": { \"enabled\": true } }"
+        enableSkyrimnetGameMasterAgentPatchJson = "{ \"gamemaster\": { \"agentEnabled\": true } }"
+    endif
+    
+    bool shouldApplyTalkToPlayerPackageCurrent = SkyrimNetApi.GetConfigBool("Game", "speech.shouldApplyTalkToPlayerPackage", true)
+    string shouldApplyTalkToPlayerPackage = "Apply TalkToPlayer Package: " + BoolToDisplayString(shouldApplyTalkToPlayerPackageCurrent)
+    string shouldApplyTalkToPlayerPackagePatchJson = ""
+    if shouldApplyTalkToPlayerPackageCurrent
+        shouldApplyTalkToPlayerPackagePatchJson = "{ \"speech\": { \"shouldApplyTalkToPlayerPackage\": false } }"
+    else
+        shouldApplyTalkToPlayerPackagePatchJson = "{ \"speech\": { \"shouldApplyTalkToPlayerPackage\": true } }"
+    endif
+
+    bool enableNarrationCurrent = SkyrimNetApi.GetConfigBool("Game", "narration.enabled", true)
+    string enableNarration = "Enable Narration: " + BoolToDisplayString(enableNarrationCurrent)
+    string enableNarrationPatchJson = ""
+    if enableNarrationCurrent
+        enableNarrationPatchJson = "{ \"narration\": { \"enabled\": false } }"
+    else
+        enableNarrationPatchJson = "{ \"narration\": { \"enabled\": true } }"
+    endif
+
+
+    string enableGameMasterAgent = "Enable Game Master Agent: " + BoolToDisplayString(enableGameMasterAgentCurrent)
+    string enableGameMasterAgentPatchJson = ""
+    if enableGameMasterAgentCurrent
+        enableGameMasterAgentPatchJson = "{ \"gamemaster\": { \"agentEnabled\": false } }"
+    else
+        enableGameMasterAgentPatchJson = "{ \"gamemaster\": { \"agentEnabled\": true } }"
+    endif
+
+    menu.AddEntryItem(title)
+    menu.AddEntryItem(enableSkyrimNet)
+    menu.AddEntryItem(enableGameMasterAgent)
+    menu.AddEntryItem(shouldApplyTalkToPlayerPackage)
+    menu.AddEntryItem(enableNarration)
+
+    menu.OpenMenu()
+        String result =  menu.GetResultString()
+
+    Debug.Trace("[SkyrimNet] Config Menu Result: " + result)
+    if result == "" || result == title
+        return
+    elseif result == enableSkyrimNet
+        bool eventSuccess = SkyrimNetApi.PatchConfig("Events", enableSkyrimnetEventTrackingPatchJson)
+        bool agentSuccess = SkyrimNetApi.PatchConfig("Game", enableSkyrimnetGameMasterAgentPatchJson)
+        OpenConfigMenu()
+        return
+    elseif result == enableGameMasterAgent
+        bool success = SkyrimNetApi.PatchConfig("game", enableGameMasterAgentPatchJson)
+        OpenConfigMenu()
+        return
+    elseif result == shouldApplyTalkToPlayerPackage
+        bool success = SkyrimNetApi.PatchConfig("game", shouldApplyTalkToPlayerPackagePatchJson)
+        OpenConfigMenu()
+        return
+    elseif result == enableNarration
+        bool success = SkyrimNetApi.PatchConfig("game", enableNarrationPatchJson)
+        OpenConfigMenu()
+        return
+    endif
+endFunction
+
+string function BoolToDisplayString(bool value) global
+    if value
+        return "Yes"
+    else
+        return "No"
+    endif
+endfunction
+

--- a/Source/Scripts/skynet_Library.psc
+++ b/Source/Scripts/skynet_Library.psc
@@ -475,44 +475,51 @@ Function InitVRIntegrations()
   
     RegisterForModEvent("skynet_vrik_trigger_player_dialogue", "OnVrikTriggerPlayerDialogue")
     VRIK.VrikAddGestureAction("skynet_vrik_trigger_player_dialogue", "SkyrimNet: Trigger Player Dialogue")
+
+
+    RegisterForModEvent("skynet_vrik_trigger_dialogue_transform", "OnVrikTriggerDialogueTransform")
+    VRIK.VrikAddGestureAction("skynet_vrik_trigger_dialogue_transform", "SkyrimNet: Start Dialogue Transform Input")
+
+    RegisterForModEvent("skynet_vrik_trigger_dialogue_transform_release", "OnVrikTriggerDialogueTransformRelease")
+    VRIK.VrikAddGestureAction("skynet_vrik_trigger_dialogue_transform_release", "SkyrimNet: Stop Dialogue Transform Input")
 EndFunction
   
-; Existing event for narration continuation
+Event OnVrikTriggerDialogueTransform(string eventName, string strArg, float numArg, Form sender)
+    SkyrimNetApi.TriggerVoiceDialogueTransformPressed()
+EndEvent
+
+Event OnVrikTriggerDialogueTransformRelease(string eventName, string strArg, float numArg, Form sender)
+    SkyrimNetApi.TriggerVoiceDialogueTransformReleased(1.0)
+EndEvent
+
 Event OnVrikContinueNarration(string eventName, string strArg, float numArg, Form sender)
     SkyrimNetApi.TriggerContinueNarration()
 EndEvent  
   
-; New event for toggling GameMaster
 Event OnVrikToggleGameMaster(string eventName, string strArg, float numArg, Form sender)
     SkyrimNetApi.TriggerToggleGameMaster()
 EndEvent
   
-; New event for triggering voice input (start recording)
 Event OnVrikTriggerVoiceInput(string eventName, string strArg, float numArg, Form sender)
     SkyrimNetApi.TriggerRecordSpeechPressed()
 EndEvent
   
-; New event for triggering voice input release (stop recording)
 Event OnVrikTriggerVoiceRelease(string eventName, string strArg, float numArg, Form sender)
     SkyrimNetApi.TriggerRecordSpeechReleased(2.0)
 EndEvent
   
-; New event for triggering direct input (start recording)
 Event OnVrikTriggerDirectInput(string eventName, string strArg, float numArg, Form sender)
     SkyrimNetApi.TriggerVoiceDirectInputPressed()
 EndEvent
   
-; New event for triggering direct input release (stop recording)
 Event OnVrikTriggerDirectRelease(string eventName, string strArg, float numArg, Form sender)
     SkyrimNetApi.TriggerVoiceDirectInputReleased(2.0)
 EndEvent
   
-; New event for triggering autonomous player thought
 Event OnVrikTriggerPlayerThought(string eventName, string strArg, float numArg, Form sender)
     SkyrimNetApi.TriggerPlayerThought()
 EndEvent
   
-; New event for triggering autonomous player dialogue
 Event OnVrikTriggerPlayerDialogue(string eventName, string strArg, float numArg, Form sender)
     SkyrimNetApi.TriggerPlayerDialogue()
 EndEvent


### PR DESCRIPTION
- Added PatchConfig function to papyrus, to allow config changes from mods
- Added SetActionCooldown, ExecuteAction and GetRemaining cooldown to papyrus API
- Add two missing actions to VRIK
- Add a simple List Menu to change some commonly toggled configs from in-game (Still needs a spell to open it, but it works)

```
bool function PatchConfig(String name, String jsonPatch) Global Native

; Makes the specified actor run the specified action. Arguments can be supplied as a json string. Runs the action irrespective of cooldowns or eligibility.
int function ExecuteAction(string actionName, Actor akOriginator, string argsJson) global native

; Sets the cooldown for the specified action
int function SetActionCooldown(string actionName, int cooldownTimeSeconds) global native

; Gets the remaining cooldown time for the specified action in seconds. Returns -1 if no cooldown is set.
int function GetRemainingCooldown(string actionName) global native
```

Requires PRs:
- https://github.com/MinLL/SkyrimNet/pull/202
- https://github.com/MinLL/SkyrimNet/pull/201