### PR TITLE
DBVO integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ SkyrimNet is a cutting-edge AI integration platform for games, beginning with Sk
 
 ### 📋 **Optional Dependencies**
 - [UIExtensions](https://www.nexusmods.com/skyrimspecialedition/mods/17561) - Required for text input and Input Wheel
+- [Dragonborn Voice Over](https://www.nexusmods.com/skyrimspecialedition/mods/84329) - Required for player-voiced vanilla lines of dialogue. To enable this feature, install DBVO but disable or delete the DBVO.esp file (no voice pack is required). SkyrimNet will then capture dialogue events from the DBVO interface file and send them to TTS, allowing the player character to speak normally unvoiced vanilla lines.
 
 ### 🎮 **Version-Specific Requirements**
 

--- a/Source/Scripts/SkyrimNetApi.psc
+++ b/Source/Scripts/SkyrimNetApi.psc
@@ -408,6 +408,9 @@ int function TriggerPlayerThought() Global Native
 ; Returns 0 on success, 1 on failure
 int function TriggerPlayerDialogue() Global Native
 
+; Sends a line of player dialogue directly to TTS, without prompting the LLM or saving to context
+int function TriggerPlayerTTS(String dialogue) Global Native
+
 ; -----------------------------------------------------------------------------
 ; --- Events ---
 ; -----------------------------------------------------------------------------

--- a/Source/Scripts/skynet_Library.psc
+++ b/Source/Scripts/skynet_Library.psc
@@ -534,11 +534,18 @@ EndFunction
   
 ; Event to intercept DBVO dialogue
 Event OnPlayDBVOTopic(string eventName, string strArg, float numArg, Form sender)
+    ; Use "off" callback if disabled
+    Bool _enabled = SkyrimNetApi.GetConfigBool("game", "dbvo.enabled", false)
+    if !_enabled
+        UI.InvokeString("Dialogue Menu", "_root.DialogueMenu_mc.startTopicClickedTimer", "off")
+        return
+    endif
+
     ; Generate and play TTS audio for the selected line of dialogue
     SkyrimNetApi.TriggerPlayerTTS(strArg)
 
     ; Additional delay over what DBVO provides, to account for TTS generation time
-    Float _delay = SkyrimNetApi.GetConfigFloat("game", "tts.dbvoInvokeDelaySeconds", 0.5)
+    Float _delay = SkyrimNetApi.GetConfigFloat("game", "dbvo.additionalDelay", 0.5)
     Utility.WaitMenuMode(_delay)
 
     ; Callback to dialoguemenu.swf. It pauses for a time based on the length of the text and then proceeds with the NPC response.


### PR DESCRIPTION
Adds support for player-voiced vanilla dialogue, with DBVO as a dependency.

1. If DBVO.esp is **not** present, add an event listener for PlayDBVOTopic, called by the dialoguemenu.swf provided by DBVO. Capture that event, containing the dialogue to be voiced, and send it to SKSE for TTS generation.
2. PlayDBVOTopic needs to send a callback to startTopicClickedTimer in the swf to make the NPC respond after a calculated delay. First wait an additional amount of time (configured on the SKSE side) and then make the callback.