### PR TITLE
Fix lip sync for Silent TTS and after animation scenes

### DIFF
--- a/Source/Scripts/SkyrimNetInternal.psc
+++ b/Source/Scripts/SkyrimNetInternal.psc
@@ -390,6 +390,14 @@ Function RentRoom_Execute(Actor akActor, string contextJson, string paramsJson) 
     skynet.libs.RentRoom_Execute(akActor, paramsJson)
 EndFunction
 
+Function ResetFacialAnimations(Actor akActor) global
+    if (akActor.IsOnMount())
+        akActor.RegenerateHead()
+    else
+        akActor.QueueNiNodeUpdate()
+    endif
+EndFunction
+
 ; bool Function GiveBanditBounty_IsEligible(Actor akActor, string contextJson, string paramsJson) global
 ;     Debug.Trace("[SkyrimNetInternal] GiveBanditBounty_IsEligible called for " + akActor.GetDisplayName())
 


### PR DESCRIPTION
Papyrus script for https://github.com/MinLL/SkyrimNet/pull/269
QueueNiNodeUpdate resets the actor's animation, stopping vanilla lip sync if it was in progress. We can use this to stop the actor's vanilla lip sync while silent TTS facial animations play.
However, QueueNiNodeUpdate should not be used while the actor is mounted, so use RegenerateHead in that case.
This also fixes stuck faces after nsfw animations.