### PR TITLE
Allow empty background speaker

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/components/event_history.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/event_history.prompt
@@ -6,7 +6,7 @@
 {% for event in events %}{% if event.type == "gamemaster_dialogue" %}{% set latestGMDialogueTime = event.gameTime %}{% endif %}{% endfor %}
 {% set hasShownGMDialogue = false %}
 {% for event in events %}
-{% if isValidActor(event.originatingActor) %}
+{% if isValidActor(event.originatingActor) or event.type == "dialogue_background" %}
     {% if event.type != "spell" and event.type != "hit" and event.type != "combat" %}
         {% set locationChanged = (lastLocation != "" and event.location != lastLocation) %}
         {% set timeDiff = gameTimeNumeric - event.gameTime %}
@@ -66,7 +66,7 @@
 [ user ]
             {% if locationChanged %}[Location changed to {{ event.location }}] {% endif %}{% if event.type == "direct_narration" %}{{ timeIndicator }}*{{ format_event(event, "verbose") }}*
             {% else %}
-            {% if event.type == "dialogue_background" %}[Background] {% endif %}{% if event.type == "player_thoughts" %}[{{ decnpc(event.originatingActor).name }}'s internal thoughts] {% endif %}{% if isValidActor(event.originatingActor) %}{{ decnpc(event.originatingActor).name }}{% if isValidActor(event.targetActor) %} (to {{ decnpc(event.targetActor).name }}){% endif %}: {% endif %}{{ format_event(event, "verbose") }}
+            {% if event.type == "dialogue_background" %}[Background] {% endif %}{% if event.type == "player_thoughts" %}[{{ decnpc(event.originatingActor).name }}'s internal thoughts] {% endif %}{% if isValidActor(event.originatingActor) %}{{ decnpc(event.originatingActor).name }}{% if isValidActor(event.targetActor) %} (to {{ decnpc(event.targetActor).name }}){% endif %}: {% else if event.type == "dialogue_background" and event.data and event.data.speaker != "" %}{{ event.data.speaker }}: {% endif %}{{ format_event(event, "verbose") }}
             {% endif %}
 [ end user ]
         {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/components/event_history_compact.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/event_history_compact.prompt
@@ -4,7 +4,7 @@
 {% for event in events %}{% if event.type == "gamemaster_dialogue" %}{% set latestGMDialogueTime = event.gameTime %}{% endif %}{% endfor %}
 {% set hasShownGMDialogue = false %}
 {% for event in events %}
-{% if isValidActor(event.originatingActor) %}
+{% if isValidActor(event.originatingActor) or event.type == "dialogue_background" %}
     {% if event.type != "spell" and event.type != "hit" and event.type != "combat" %}
         {% set locationChanged = (lastLocation != "" and event.location != lastLocation) %}
         {% set timeDiff = gameTimeNumeric - event.gameTime %}
@@ -55,7 +55,7 @@
         {% else if event.type == "direct_narration" %}
 - {{ timeIndicator }}*{{ format_event(event, "compact") }}*
         {% else %}
-- [{{ short_time(event.gameTimeStr) }}] {% if locationChanged %}[Now at {{ event.location }}] {% endif %}({{ event.type }}){% if event.type == "dialogue" or event.type == "dialogue_npc" or event.type == "dialogue_player" or event.type == "dialogue_player_stt" or event.type == "dialogue_player_text" or event.type == "dialogue_background"%} {{ decnpc(event.originatingActor).name }}{% if isValidActor(event.targetActor) %} to {{ decnpc(event.targetActor).name }}{% endif %}{% else %} {{ decnpc(event.originatingActor).name }}{% endif %}: {{ format_event(event, "compact") }}
+- [{{ short_time(event.gameTimeStr) }}] {% if locationChanged %}[Now at {{ event.location }}] {% endif %}({{ event.type }}) {% if event.type == "dialogue" or event.type == "dialogue_npc" or event.type == "dialogue_player" or event.type == "dialogue_player_stt" or event.type == "dialogue_player_text" or event.type == "dialogue_background"%}{% if isValidActor(event.originatingActor) %}{{ decnpc(event.originatingActor).name }}{% if isValidActor(event.targetActor) %} to {{ decnpc(event.targetActor).name }}{% endif %}: {% else if event.type == "dialogue_background" and event.data and event.data.speaker != "" %}{{ event.data.speaker }}: {% endif %}{% else %}{{ decnpc(event.originatingActor).name }}: {% endif %}{{ format_event(event, "compact") }}
         {% endif %}
 
         {% set lastLocation = event.location %}

--- a/SKSE/Plugins/SkyrimNet/prompts/components/event_history_verbose.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/event_history_verbose.prompt
@@ -3,7 +3,7 @@
 {% set lastSignificantTime = 0 %}
 
 {% for event in events %}
-{% if isValidActor(event.originatingActor) and event.type != "gamemaster_dialogue" %}
+{% if (isValidActor(event.originatingActor) and event.type != "gamemaster_dialogue") or event.type == "dialogue_background" %}
     {% if lastSignificantTime > 0 %}
         {% set timeSinceLastSignificant = event.gameTime - lastSignificantTime %}
     {% else %}
@@ -32,7 +32,7 @@
     {% if event.type == "direct_narration" %}
 [{{ short_time(event.gameTimeStr) }}] [{{ event.location }}] *{{ format_event(event, "verbose") }}*
     {% else %}
-[{{ short_time(event.gameTimeStr) }}] [{{ event.location }}] ({{ event.type }}){% if event.type == "dialogue" or event.type == "dialogue_npc" or event.type == "dialogue_player" or event.type == "dialogue_player_stt" or event.type == "dialogue_player_text" or event.type == "dialogue_background" or event.type == "player_thoughts" %} {{ decnpc(event.originatingActor).name }}{% if isValidActor(event.targetActor) %} to {{ decnpc(event.targetActor).name }}{% endif %}{% else %} {{ decnpc(event.originatingActor).name }}{% endif %}: {{ format_event(event, "verbose") }}
+[{{ short_time(event.gameTimeStr) }}] [{{ event.location }}] ({{ event.type }}) {% if event.type == "dialogue" or event.type == "dialogue_npc" or event.type == "dialogue_player" or event.type == "dialogue_player_stt" or event.type == "dialogue_player_text" or event.type == "dialogue_background" or event.type == "player_thoughts" %}{% if isValidActor(event.originatingActor) %}{{ decnpc(event.originatingActor).name }}{% if isValidActor(event.targetActor) %} to {{ decnpc(event.targetActor).name }}{% endif %}: {% else if event.type == "dialogue_background" and event.data and event.data.speaker != "" %}{{ event.data.speaker }}: {% endif %}{% else %}{{ decnpc(event.originatingActor).name }}: {% endif %}{{ format_event(event, "verbose") }}
     {% endif %}
 
     {% set lastEventTime = event.gameTime %}


### PR DESCRIPTION
For dialogue_background events, allows the speaker name to be blank, to support Daedric quests like Azura speaking to you. Azura is not a valid actor, so the current prompt would filter out her speech.

Required for https://github.com/MinLL/SkyrimNet/pull/509