### PR TITLE
Remove dead Papyrus package dispatch functions

### DIFF
--- a/Source/Scripts/SkyrimNetInternal.psc
+++ b/Source/Scripts/SkyrimNetInternal.psc
@@ -64,26 +64,6 @@ Function SetLookAt(Actor akActor, Actor akTarget = None) global
     endif
 EndFunction
 
-Function AddPackageToActor(Actor akActor, string packageName, int priority, int flags) global
-    Debug.Trace("[SkyrimNetInternal] AddPackageToActor called for " + akActor.GetDisplayName() + " with package " + packageName + " and priority " + priority + " and flags " + flags)
-    skynet_MainController skynet = ((Game.GetFormFromFile(0x0802, "SkyrimNet.esp") as Quest) As skynet_MainController)
-    if !skynet
-        Debug.MessageBox("Fatal Error: AddPackageToActor failed to retrieve controller.")
-        return
-    endif
-    skynet.libs.ApplyPackageOverrideToActor(akActor, packageName, priority, flags)
-EndFunction
-
-Function RemovePackageFromActor(Actor akActor, string packageName) global
-    Debug.Trace("[SkyrimNetInternal] RemovePackageFromActor called for " + akActor.GetDisplayName() + " with package " + packageName)
-    skynet_MainController skynet = ((Game.GetFormFromFile(0x0802, "SkyrimNet.esp") as Quest) As skynet_MainController)
-    if !skynet
-        Debug.MessageBox("Fatal Error: RemovePackageFromActor failed to retrieve controller.")
-        return
-    endif
-    skynet.libs.RemovePackageOverrideFromActor(akActor, packageName)
-EndFunction
-
 ; -----------------------------------------------------------------------------
 ; --- Player Input Handlers ---
 ; -----------------------------------------------------------------------------

--- a/Source/Scripts/skynet_Library.psc
+++ b/Source/Scripts/skynet_Library.psc
@@ -124,47 +124,6 @@ Function RegisterActions()
 EndFunction
 
 ; -----------------------------------------------------------------------------
-; --- Skynet Package Parsing ---
-; -----------------------------------------------------------------------------
-
-Package Function GetPackageFromString(String asPackage)
-    if asPackage == "TalkToPlayer"
-        return packageDialoguePlayer
-    elseif asPackage == "TalkToNPC"
-        return packageDialogueNPC
-    elseif asPackage == "FollowPlayer"
-        return packageFollowPlayer
-    endif
-    return None
-EndFunction
-
-Function ApplyPackageOverrideToActor(Actor akActor, String asString, Int priority = 1, Int flags = 0)
-    Package _pck = GetPackageFromString(asString)
-    if !_pck
-        skynet.Error("Could not retrieve package for: " + asString)
-        return
-    endif
-    skynet.Info("Applying package override " + asString + " to " + akActor.GetDisplayName())
-    ActorUtil.AddPackageOverride(akActor, _pck, priority, flags)
-    akActor.EvaluatePackage()
-    DispatchPackageAddedEvent(akActor, _pck, asString)
-    skynet.Info("Dispatched package remove event for " + akActor.GetDisplayName() + " with package " + asString)
-EndFunction
-
-Function RemovePackageOverrideFromActor(Actor akActor, String asString)
-    Package _pck = GetPackageFromString(asString)
-    if !_pck
-        skynet.Error("Could not retrieve package for: " + asString)
-        return
-    endif
-    skynet.Info("Removing package override " + asString + " from " + akActor.GetDisplayName())
-    ActorUtil.RemovePackageOverride(akActor, _pck)
-    akActor.EvaluatePackage()
-    DispatchPackageRemovedEvent(akActor, _pck, asString)
-    skynet.Info("Dispatched package remove event for " + akActor.GetDisplayName() + " with package " + asString)
-EndFunction
-
-; -----------------------------------------------------------------------------
 ; --- Skynet Papyrus Actions ---
 ; -----------------------------------------------------------------------------
 
@@ -485,30 +444,6 @@ Bool Function RegisterTags()
     return true
 EndFunction
 
-
-; -----------------------------------------------------------------------------
-; --- Event Dispatchers
-; -----------------------------------------------------------------------------
-
-Function DispatchPackageAddedEvent(Actor akActor, Package pkg, String packageName)
- int handle = ModEvent.Create("SkyrimNet_OnPackageAdded")
-  if handle
-    modEvent.PushForm(handle,akActor)
-    modEvent.PushForm(handle,pkg)
-    modEvent.PushString(handle, packageName)
-    modEvent.Send(handle)
-endif
-EndFunction
-
-Function DispatchPackageRemovedEvent(Actor akActor, Package pkg, String packageName)
- int handle = ModEvent.Create("SkyrimNet_OnPackageRemoved")
-  if handle
-    modEvent.PushForm(handle,akActor)
-    modEvent.PushForm(handle,pkg)
-    modEvent.PushString(handle, packageName)
-    modEvent.Send(handle)
-endif
-EndFunction
 
 ; -----------------------------------------------------------------------------
 ; ---- VRIK Integration ----


### PR DESCRIPTION
## Summary
- Removed 7 dead Papyrus functions (85 lines) that were part of the old Papyrus VM dispatch chain
- Package dispatch now goes directly through C++ via PapyrusUtilBridge, making these script functions unreachable

## Removed functions
- `SkyrimNetInternal.AddPackageToActor()` / `RemovePackageFromActor()`
- `skynet_Library.ApplyPackageOverrideToActor()` / `RemovePackageOverrideFromActor()`
- `skynet_Library.GetPackageFromString()` / `DispatchPackageAddedEvent()` / `DispatchPackageRemovedEvent()`

## Test plan
- [x] Grep confirms no remaining callers in Scripts directory
- [x] In-game: package application still works via direct C++ path

🤖 Generated with [Claude Code](https://claude.com/claude-code)