### PR TITLE
feat: Add Silent Narration hotkey support

### DIFF
--- a/Source/Scripts/SkyrimNetApi.psc
+++ b/Source/Scripts/SkyrimNetApi.psc
@@ -658,6 +658,15 @@ int function TriggerGenerateDiaryBio() Global Native
 ; Returns 0 on success, 1 on failure
 int function TriggerInterruptDialogue(bool abDeferToCurrentFinished = false) Global Native
 
+; Simulates pressing the silent narration hotkey
+; - Shows "Enter silent narration text..." notification
+; - Opens text input dialog for silent event registration
+; - Registers a persistent_generic event that informs actors without triggering NPC responses
+; - Useful for establishing facts or outcomes without causing dialogue
+; Functions identically to pressing the configured silent narration key
+; Returns 0 on success
+int function TriggerSilentNarration() Global Native
+
 ; -----------------------------------------------------------------------------
 ; --- Events ---
 ; -----------------------------------------------------------------------------

--- a/Source/Scripts/skynet_Library.psc
+++ b/Source/Scripts/skynet_Library.psc
@@ -680,6 +680,7 @@ Int Property hotkeyToggleOpenMic = -1 Auto Hidden
 Int Property hotkeyCaptureCrosshair = -1 Auto Hidden
 Int Property hotkeyGenerateDiaryBio = -1 Auto Hidden
 Int Property hotkeyInterruptDialogue = -1 Auto Hidden
+Int Property hotkeySilentNarration = -1 Auto Hidden
 
 Bool Property inGameHotkeysEnabled = false Auto Hidden
 
@@ -780,6 +781,9 @@ Function RegisterConfiguredHotkeys()
     If hotkeyInterruptDialogue != -1
         RegisterForKey(hotkeyInterruptDialogue)
     EndIf
+    If hotkeySilentNarration != -1
+        RegisterForKey(hotkeySilentNarration)
+    EndIf
 EndFunction
 
 Function UnregisterAllHotkeys()
@@ -834,6 +838,9 @@ Function UnregisterAllHotkeys()
     EndIf
     If hotkeyInterruptDialogue != -1
         UnregisterForKey(hotkeyInterruptDialogue)
+    EndIf
+    If hotkeySilentNarration != -1
+        UnregisterForKey(hotkeySilentNarration)
     EndIf
 EndFunction
 
@@ -982,6 +989,8 @@ Function HandleHotkeyPress(Int keyCode)
         SkyrimNetApi.TriggerGenerateDiaryBio()
     ElseIf keyCode == hotkeyInterruptDialogue && hotkeyInterruptDialogue != -1
         SkyrimNetApi.TriggerInterruptDialogue()
+    ElseIf keyCode == hotkeySilentNarration && hotkeySilentNarration != -1
+        SkyrimNetApi.TriggerSilentNarration()
     EndIf
 EndFunction
 

--- a/Source/Scripts/skynet_McmScript.psc
+++ b/Source/Scripts/skynet_McmScript.psc
@@ -23,6 +23,7 @@ int optionHotkeyToggleOpenMic
 int optionHotkeyCaptureCrosshair
 int optionHotkeyGenerateDiaryBio
 int optionHotkeyInterruptDialogue
+int optionHotkeySilentNarration
 
 int useImage
 
@@ -288,6 +289,7 @@ function DisplayHotkeys()
         optionHotkeyCaptureCrosshair = AddKeyMapOption("Capture Target (Hold: Player)", library.hotkeyCaptureCrosshair)
         optionHotkeyGenerateDiaryBio = AddKeyMapOption("Generate Diary & Bio", library.hotkeyGenerateDiaryBio)
         optionHotkeyInterruptDialogue = AddKeyMapOption("Interrupt Dialogue", library.hotkeyInterruptDialogue)
+        optionHotkeySilentNarration = AddKeyMapOption("Silent Narration", library.hotkeySilentNarration)
     else
         AddTextOption("Enable in-game hotkeys to configure", "")
     endif
@@ -996,8 +998,11 @@ event OnOptionKeyMapChange(int option, int keyCode, string conflictControl, stri
     elseif option == optionHotkeyInterruptDialogue
         library.hotkeyInterruptDialogue = finalKeyCode
         SetKeyMapOptionValue(option, keyCode)
+    elseif option == optionHotkeySilentNarration
+        library.hotkeySilentNarration = finalKeyCode
+        SetKeyMapOptionValue(option, keyCode)
     endif
-    
+
     ; Re-register hotkeys to pick up the change immediately
     if library.inGameHotkeysEnabled
         library.UnregisterAllHotkeys()
@@ -1061,8 +1066,11 @@ event OnOptionDefault(int option)
     elseif option == optionHotkeyInterruptDialogue
         library.hotkeyInterruptDialogue = -1
         SetKeyMapOptionValue(option, -1)
+    elseif option == optionHotkeySilentNarration
+        library.hotkeySilentNarration = -1
+        SetKeyMapOptionValue(option, -1)
     endif
-    
+
     ; Re-register hotkeys to pick up the change immediately
     if library.inGameHotkeysEnabled
         library.UnregisterAllHotkeys()

--- a/Source/Scripts/skynet_WheelMenu.psc
+++ b/Source/Scripts/skynet_WheelMenu.psc
@@ -10,8 +10,8 @@ EndEvent
 ;I had to make some sub menus because the wheel menu only supports 9 items
 Function DisplayWheel() global
 
-    string labels = "Text Input,Text Thought,Text Roleplay,Direct Input,Think to Self,Auto Roleplay,Utilities"
-    string options = "Text Input,Text Thought,Text Roleplay,Direct Input,Think to Self,Auto Roleplay,Utilities Menu"
+    string labels = "Text Input,Text Thought,Text Roleplay,Direct Input,Think to Self,Auto Roleplay,Utilities,Silent Narration"
+    string options = "Text Input,Text Thought,Text Roleplay,Direct Input,Think to Self,Auto Roleplay,Utilities Menu,Silent Narration"
 
     int result = skynet_WheelMenu.MenuWheel(StringUtil.Split(options, ","), StringUtil.Split(labels, ","))
 
@@ -36,6 +36,9 @@ Function DisplayWheel() global
     elseif result == 6
         ; Utilities submenu
         skynet_WheelMenu.DisplayUtilities()
+    elseif result == 7
+        ; Silent narration - register event without NPC response
+        SkyrimNetApi.TriggerSilentNarration()
     endif
 
 EndFunction


### PR DESCRIPTION
## Summary
- Add `TriggerSilentNarration()` native function declaration to `SkyrimNetApi.psc`
- Add "Silent Narration" as 8th option on main wheel menu
- Add `hotkeySilentNarration` property with register/unregister/handler in `skynet_Library.psc`

Companion PR to MinLL/SkyrimNet#584

## Test plan
- [ ] Open wheel menu — verify "Silent Narration" appears on main wheel
- [ ] Select it — verify text input opens and registers persistent_generic event
- [ ] Assign hotkeySilentNarration in-game — verify hotkey triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)