### PR TITLE
add Player2 App as alternative backend to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ You can confirm that CUDA is being used on the Test & Easy Setup page in the Spe
 - **LLM Provider**: OpenRouter API key (or compatible OpenAI API)
 - **Cloud Processing**: VastAI account (optional, for cloud GPU access and automatic XTTS provisioning)
 
+### 🎮 **Alternative: [Player2 App](https://player2.game) (All-in-One Backend)**
+
+The [Player2 App](https://player2.game) provides LLM, TTS, and STT through a single local application — no separate API keys or cloud setup needed.
+
+1. **Download and install** the [Player2 App](https://player2.game)
+2. **Configure SkyrimNet** via the web UI at [localhost:8080](http://localhost:8080):
+   - **Language Model** — set API URL to `http://127.0.0.1:4315/v1/chat/completions`
+   - **ElevenLabs TTS** — set API URL to `http://127.0.0.1:4315/v1/tts/eleven`
+   - **External Whisper STT** — set API URL to `http://127.0.0.1:4315/v1/stt/whisper`
+   - **API Token** — use `skyrimnet` for all three services
+3. **Map voices** in the Player2 Settings page to assign ElevenLabs voices for your in-game characters
+
 ## 🎪 Key Features
 
 ### 🧠 **AI Capabilities**


### PR DESCRIPTION
  hey! I've been tinkering with SkyrimNet recently and got it running on Player2 with pretty minimal config changes - just pointing the three endpoints (LLM, TTS, STT) at the local app and you're good to go.

  figured it might be handy to have a quick setup note in the README for anyone who wants to try it out, so this adds a small section right after the External API Requirements with the three URLs and token config.

  the nice thing is it bundles LLM + ElevenLabs TTS + Whisper STT into one app, so there's no juggling separate API keys or cloud setup. once it's running you can also map ElevenLabs voices to in-game characters from the Player2 settings page.

  happy to adjust the wording or placement if you'd prefer it somewhere else!