### PR TITLE
Fix weather missing from dialogue prompts

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/components/context/scene_context.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/context/scene_context.prompt
@@ -42,6 +42,7 @@
     {% endif %}
 {% endblock %}
 
+{% block weather %}
 ## Current Weather
 **Weather**: {% if is_indoors %}You are indoors and sheltered from the weather. Outside, it is {% endif %}{{ currentWeather.name }}{% if currentWeather.isRaining %} (Raining){% else if currentWeather.isSnowing %} (Snowing){% endif %}
 {% if currentWeather.isRaining and currentWeather.isSnowing %}
@@ -53,6 +54,7 @@
 {% else if currentWeather.windSpeed > 0.5 %}
     *{% if is_indoors %}Outside, {%endif %}Strong winds are blowing*
 {% endif %}
+{% endblock %}
 
 ## Current Location
 {% block currentLocation %}

--- a/SKSE/Plugins/SkyrimNet/prompts/components/context/scene_context_full.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/context/scene_context_full.prompt
@@ -4,6 +4,9 @@
 {% block situationSummary %}
 {% endblock %}
 
+{% block weather %}
+{% endblock %}
+
 ## Nearby People
 {% block nearbyNpcs %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Weather section in `scene_context.prompt` was not wrapped in a `{% block %}` tag, so `scene_context_full.prompt` (the render mode used by dialogue) silently dropped it
- NPCs had no weather awareness — rain, snow, wind were never included in dialogue prompts
- Wrapped weather in `{% block weather %}` and added it to the full render mode template

## Test plan
- [x] Verified via MCP `render_template` that `dialogue_response` now includes `## Current Weather` section
- [x] Confirmed weather data resolves correctly (e.g. "RainPF (Raining)" with description)
- [x] Hot-reloaded templates in-game and confirmed fix is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)