### PR TITLE
Filter IntelEngine quest from generic list, use decorator instead

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/player_thoughts.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/player_thoughts.prompt
@@ -34,7 +34,11 @@ Express a genuine {{ decnpc(npc.UUID).name }} thought on this topic:
 {% if selectedQuests and length(selectedQuests) > 0 %}
 ## Active Quests
 {% for quest in selectedQuests %}
+{% if quest.name == "IntelEngine" %}
+{{ get_intelengine_quests(npc.UUID) }}
+{% else %}
 **{{ quest.name }}** ({{ quest.type }}):{% for objective in quest.objectives %} {{ objective.objectiveText }}{% if objective.isCompleted %} (Done){% endif %}{% if not loop.is_last %};{% endif %}{% endfor %}
+{% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
IntelEngine's quest appears as "IntelEngine (None): Investigate the threat near Bandit" in the quest list — no useful context for NPCs.

IntelEngine now registers a get_intelengine_quests decorator via PublicAPI that provides rich quest details (location, type, quest giver, briefing). This change filters IntelEngine's quest from the generic rendering and calls the decorator instead.

Soft dependency: if IntelEngine is not installed, the quest name "IntelEngine" never appears in the list so the filter is a no-op.