### PR TITLE
Actions master switch wiring + NPC Thoughts gameplugin

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/npc_thoughts.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/npc_thoughts.prompt
@@ -1,0 +1,53 @@
+[ system ]
+You are {{ decnpc(npc.UUID).name }}, a {{ decnpc(npc.UUID).gender }} {{ decnpc(npc.UUID).race }} in Skyrim.
+
+{{ render_subcomponent("system_head", "thoughts") }}
+[ end system ]
+
+{{ render_template("components\\event_history") }}
+
+
+[ user ]
+{{ render_subcomponent("user_final_instructions", "thoughts") }}
+{% if length(promptForThoughts) > 0 %}
+## ⚠️ REQUIRED THOUGHT TOPIC ⚠️
+**Think about this:** "{{ promptForThoughts }}"
+
+This is a private internal thought — NOT dialogue. No one hears it. Do not address anyone. Do not continue the conversation from event history.
+
+Express a genuine {{ decnpc(npc.UUID).name }} thought on this topic:
+- Draw from your character profile, personality, and feelings
+- Stay in character — this is your private thought, colored by your history and emotions
+{% if is_in_combat(npc.UUID) %}
+- You're in combat — keep it raw and urgent
+{% endif %}
+
+---
+
+{% endif %}
+
+{% if triggeringEvent and triggeringEvent.type %}
+## What Just Happened
+{{ format_event(triggeringEvent, "verbose") }}
+What's your gut reaction? A flash of feeling, a suspicion, a memory stirred — whatever surfaces in the moment.
+
+{% elif is_in_combat(npc.UUID) %}
+## In Combat
+Think about how this fight feels — the fear or fury, the pain, what drives you to keep swinging.
+
+{% else %}
+## Reflect
+What are you feeling right now? Don't describe what's happening — feel it.
+{% endif %}
+
+## FINAL INSTRUCTION
+This is a **silent, unvoiced internal thought**. It will never be spoken aloud and no one — not even the player — will hear it. It is logged only to your own memory.
+
+{% if length(promptForThoughts) > 0 %}
+Express this as {{ decnpc(npc.UUID).name }}'s internal thought in their own voice, staying close to the meaning: {{ promptForThoughts }}
+{% else %}
+Respond as {{ decnpc(npc.UUID).name }}'s private, unspoken reflection.
+{% endif %}
+
+Respond with 1–2 sentences of silent internal thought only. No quoted speech. No asterisks for actions. Just the thought itself, in {{ decnpc(npc.UUID).name }}'s voice.
+[ end user ]

--- a/Source/Scripts/SkyrimNetApi.psc
+++ b/Source/Scripts/SkyrimNetApi.psc
@@ -247,6 +247,23 @@ int function RegisterPersistentEventByUUID(String content, String originatorUuid
 ; Returns 0 on success, 1 on failure (including empty text)
 int function TransformDialogue(String dialogueText) Global Native
 
+; Generate an unvoiced NPC thought and persist it to the NPC's event history.
+; The thought is generated asynchronously via the LLM and stored as an EVENT_NPC_THOUGHTS
+; event whose audience is the thinking NPC only — private by default, never spoken aloud,
+; and never heard by other NPCs or the player. It will surface in that NPC's prompts
+; (dialogue, actions, etc.) on subsequent LLM calls, coloring their behavior.
+;
+; Respects per-NPC and global cooldowns from NpcThoughts.yaml. Skips silently if the NPC
+; is dead/unconscious/sleeping or if the caller passes the player (use TriggerPlayerThought
+; for the player).
+;
+; Examples:
+; GenerateNPCThought(guardRef, "You just saw the player pick a lock")
+; GenerateNPCThought(followerRef, "The Jarl insulted your honor — how do you feel?")
+;
+; Returns 0 on success, 1 on failure (null actor or unresolvable entity)
+int function GenerateNPCThought(Actor npcActor, String promptHint) Global Native
+
 ; -----------------------------------------------------------------------------
 ; --- Utility Functions ---
 ; -----------------------------------------------------------------------------

--- a/Source/Scripts/SkyrimNetApi.psc
+++ b/Source/Scripts/SkyrimNetApi.psc
@@ -512,6 +512,12 @@ int function TriggerToggleContinuousMode() Global Native
 ; Functions identically to pressing the configured world event reactions toggle key
 int function TriggerToggleWorldEventReactions() Global Native
 
+; Toggles the runtime master switch for NPC action execution
+; - Disables BOTH embedded-in-dialogue actions and the separate-call action evaluation flow
+; - Shows notification with current state (Actions: ON/OFF)
+; - Runtime only: not persisted to config, resets to enabled on game restart
+int function TriggerToggleActions() Global Native
+
 ; --- Interaction Control Functions ---
 
 ; Simulates pressing the whisper mode toggle hotkey

--- a/Source/Scripts/skynet_WheelMenu.psc
+++ b/Source/Scripts/skynet_WheelMenu.psc
@@ -33,10 +33,10 @@ EndFunction
 
 Function DisplayUtilities() global
 
-    string labels = "Go Back,Toggle GameMaster,Toggle NPC Reactions,Continue Narration,Toggle Continuous Mode,Toggle Whisper Mode,Interrupt Dialogue"
-    string options = "Go Back,Toggle GameMaster,Toggle NPC Reactions,Continue Narration,Toggle Continuous Mode,Toggle Whisper Mode,Interrupt Dialogue"
+    string labels = "Go Back,Toggle GameMaster,Toggle NPC Reactions,Toggle Actions,Continue Narration,Toggle Continuous Mode,Toggle Whisper Mode,Interrupt Dialogue"
+    string options = "Go Back,Toggle GameMaster,Toggle NPC Reactions,Toggle Actions,Continue Narration,Toggle Continuous Mode,Toggle Whisper Mode,Interrupt Dialogue"
 
-    ; Option 7: White/Blacklist management only if there's a target under the crosshair
+    ; Option 8: White/Blacklist management only if there's a target under the crosshair
     Actor akTarget = GetTargetFromCrosshair()
     If akTarget
         labels += ",White/Blacklist Mgmt"
@@ -54,18 +54,21 @@ Function DisplayUtilities() global
         ; Toggle NPC reactions to world events
         SkyrimNetApi.TriggerToggleWorldEventReactions()
     elseif result == 3
+        ; Toggle runtime master switch for NPC actions (embedded + separate-call flows)
+        SkyrimNetApi.TriggerToggleActions()
+    elseif result == 4
         ; Continue narration
         SkyrimNetApi.TriggerContinueNarration()
-    elseif result == 4
+    elseif result == 5
         ; Toggle continuous mode
         SkyrimNetApi.TriggerToggleContinuousMode()
-    elseif result == 5
+    elseif result == 6
         ; Toggle whisper mode
         SkyrimNetApi.TriggerToggleWhisperMode()
-    elseif result == 6
+    elseif result == 7
         ; Interrupt all ongoing dialogue
         SkyrimNetApi.TriggerInterruptDialogue()
-    elseif result == 7
+    elseif result == 8
         ; White/Blacklist management submenu
         ; This option only appears if there's a target under the crosshair
         skynet_WheelMenu.DisplayFactionManagement(akTarget)


### PR DESCRIPTION
Companion PR for the NPC Thoughts feature in SkyrimNet-Core (PR #727) plus the Papyrus/game-side wiring for the runtime Actions master switch already present in core.

Two commits, each self-contained:

## 1. Actions: runtime master switch Papyrus wiring
Counterpart to \`los/actions-runtime-master-switch\` in SkyrimNet-Core.
- \`SkyrimNetApi.TriggerToggleActions()\` Papyrus declaration
- "Toggle Actions" entry added to the utilities wheel menu (\`skynet_WheelMenu.psc\`), with the subsequent option indices renumbered

Toggling disables both embedded-in-dialogue actions and the separate-call action evaluation flow. Runtime only — resets on game restart.

## 2. NPC Thoughts: template and Papyrus API
Counterpart to \`los/npc-thoughts\` in SkyrimNet-Core (SkyrimNet PR #727).
- \`SKSE/Plugins/SkyrimNet/prompts/npc_thoughts.prompt\` — new Inja template for the NPC internal-thought generation. Renders the thought as unvoiced, silent, and private.
- \`SkyrimNetApi.GenerateNPCThought(Actor npcActor, String promptHint)\` Papyrus native declaration.

The core-side DLL resolves \`npc_thoughts\` by \`NPC_THOUGHTS_PROMPT\` (\`include/prompt_constants.h\`) — without this template file, trigger-driven and Papyrus-driven NPC thoughts would fail template lookup at runtime.

## Test plan
- [ ] Papyrus compiler accepts both new function declarations
- [ ] Wheel menu shows "Toggle Actions" between "Toggle NPC Reactions" and "Continue Narration"; selecting it shows a notification and toggles action execution
- [ ] With the core DLL from PR #727 loaded: \`/npcthink Lydia\` (in the chat overlay) produces an \`EVENT_NPC_THOUGHTS\` event — template renders without errors in \`SkyrimNet.log\`
- [ ] Papyrus: \`cgf "SkyrimNetApi.GenerateNPCThought" <targetActor> "test prompt"\` dispatches a thought