### PR TITLE
native_action_selector_drilldown: add NPC profile + introduce "action" render mode hook

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/native_action_selector_drilldown.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/native_action_selector_drilldown.prompt
@@ -7,6 +7,7 @@
     - If {{ npc.name }}'s dialogue implies, suggests, or leads toward any eligible action — select it.
     - Agreement can be implicit — positive responses or steps toward fulfilling a request count.
     - Do NOT choose dramatic or aggressive actions unless clearly signaled in the dialogue or situation.
+    - Consider {{ npc.name }}'s current physical and emotional state when selecting.
     - For actions with actor parameters, use the actor's display name exactly as shown in Nearby Actors or in the PARAMS choices.
     - Respond with EXACTLY one line. Never output multiple action lines — only the first is processed by the game engine, the rest are discarded.
 
@@ -21,6 +22,9 @@
     - `ACTION: ActionName PARAMS: {"param_name1": "value1", ...}`
     - `ACTION: None`
     {% endif %}
+
+    ## {{ npc.name }}'s Profile
+    {{ render_character_profile("action", npc.UUID) }}
 [ end system ]
 
 [ user ]


### PR DESCRIPTION
Two additions to `native_action_selector_drilldown.prompt`, plus introduction of a new `"action"` render mode as a documented extension point for plugins that define action categories.

The drilldown prompt only fires when a plugin has defined an action category — vanilla upstream actions are all direct, so this prompt is fundamentally plugin-author territory. Goal of the PR is to give plugin authors better context to work with at the drilldown stage.

No engine, API, or decorator changes — `render_character_profile` already accepts arbitrary render-mode strings.

## Changes

**1. Add NPC profile to the system block, using new `"action"` render mode**

The selector prompt renders `render_character_profile("full", npc.UUID)` so the LLM has the character in scope when picking which broad action to fire. The drilldown — which picks the *concrete* action within an already-chosen category — currently has zero character context.

```jinja
## {{ npc.name }}'s Profile
{{ render_character_profile("action", npc.UUID) }}
```

The `"action"` render mode is intentionally distinct from `"full"`:
- **`"full"`** (selector use) — heavy bio render with personality, background, aspirations, appearance, skills, relationships, etc. Right for the selector phase where the LLM is choosing among broad action categories and benefits from full character grounding.
- **`"action"`** (drilldown use) — purpose-built lightweight render for the drilldown phase, where the category has already narrowed the decision. Bio submodules opt in by gating on `{% if render_mode == "action" %}` to expose only the action-relevant fields they care about.

**2. Add emotional-state guideline**

```
- Consider {{ npc.name }}'s current physical and emotional state when selecting.
```

Surfaces the same idea explicitly in the guideline list rather than leaving it implicit in the profile.

## Extension hook for plugin authors

`render_character_profile` already passes any string as the `render_mode` context variable — bio templates choose what to render via `{% if render_mode == "..." %}` checks. By calling `render_character_profile("action", npc.UUID)` in the drilldown, this PR formalizes `"action"` as the convention for plugin authors who want to expose action-decision-relevant context (inventory, gold, owned properties, known spells, current outfit, survival state, etc.) without bloating the heavier `"full"` render used elsewhere.

A plugin author opting in writes:

```jinja
{% if render_mode == "action" %}
... action-relevant bio content ...
{% endif %}
```

Or extends an existing mode-list:

```jinja
{% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" or render_mode == "action" %}
... existing bio content, now also rendered for action contexts ...
{% endif %}
```

## Test plan

1. **Profile renders in drilldown:** Trigger a plugin-defined category → drilldown handoff. With bio submodules gating on `"action"`, the drilldown's `## NPC's Profile` section renders the opted-in content.

2. **Character-trait-driven drilldown:** Drilldown a `Combat` category (or equivalent) twice — once with a cowardly NPC, once with a brave one, with matching dialogue. With `"action"` mode wired to surface relevant traits: brave NPC leans toward `AttackTarget`, cowardly leans toward `Yield`.

3. **Token delta:** Drilldown prompt grows by the profile render output (depends on what bio submodules opt in to `"action"`) plus one guideline bullet.

## Non-breaking

- `render_character_profile` is the same call shape used by the selector and many other upstream prompts; `render_mode` accepts arbitrary strings.
- No engine changes.
- Drilldown-only — selector and embedded prompts unchanged.
- Purely additive: new system-block section + one guideline bullet.

## Intentionally excluded

Not porting the selector's Nearby Actors enrichments (virtual-NPC filter, dead-corpse tag, summoned/reanimated hostility tags) to the drilldown — by drilldown the category has narrowed the decision space and the bare `name (gender race, distance)` Nearby Actors loop has been working well in production. Happy to add for symmetry if maintainers prefer.