### PR TITLE
0750_embedded_actions: teach categories + intent format

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0750_embedded_actions.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0750_embedded_actions.prompt
@@ -3,8 +3,9 @@
 After your dialogue, you may optionally perform ONE action if appropriate. Output dialogue FIRST, then action on a separate line.
 
 **Action Format:**
-- `ACTION: ActionName` — action with no parameters  
+- `ACTION: ActionName` — action with no parameters
 - `ACTION: ActionName PARAMS: {"param": "value"}` — action with parameters
+- `ACTION: CategoryName PARAMS: {"intent": "what you intend to do"}` — REQUIRED for categories
 - Omit the ACTION line entirely if no action fits
 
 **Available Actions:**
@@ -16,5 +17,7 @@ After your dialogue, you may optionally perform ONE action if appropriate. Outpu
 - Only use an action if it matches what you said, agreed to, or are doing
 - Agreement can be implicit—positive responses or steps toward fulfilling a request count
 - You can initiate actions unprompted if it fits your character
+- Some entries are **action categories** that group related actions (e.g., "Inventory", "Economy"). Selecting a category triggers a follow-up to pick the specific action within it
+- **REQUIRED**: When selecting a category, you MUST include `PARAMS: {"intent": "..."}` describing what you intend to do. Example: `ACTION: Economy PARAMS: {"intent": "sell a health potion to the player for 450 gold"}`. Category selections without intent will fail.
 - Output dialogue lines BEFORE the ACTION line (this allows speech to start while action is parsed)
 {% endif %}


### PR DESCRIPTION
Same gap-fix as #356 (`native_action_selector`), applied to the embedded-actions submodule. Categories selected via the embedded action format silently fail today because the prompt never tells the LLM that some entries are categories or that category selections require `PARAMS: {"intent": "..."}`.

The drilldown engine handles category routing fine — the missing piece is the prompt-level guidance for the LLM. In embedded mode, when the LLM outputs an action inline alongside dialogue, it pattern-matches the visible action format examples and never sees the category shape, so it emits `ACTION: CategoryName` with schema-shaped fake params instead of `intent`.

This is plugin-author territory — vanilla upstream actions are all direct, so categories only exist when a plugin defines them. PR is purely additive: one format example line + two guideline bullets.

No engine, API, or decorator changes.

## Changes

**1. Add category response format to the Action Format list**

Currently:
```
- `ACTION: ActionName` — action with no parameters
- `ACTION: ActionName PARAMS: {"param": "value"}` — action with parameters
- Omit the ACTION line entirely if no action fits
```

After this PR:
```
- `ACTION: ActionName` — action with no parameters
- `ACTION: ActionName PARAMS: {"param": "value"}` — action with parameters
- `ACTION: CategoryName PARAMS: {"intent": "what you intend to do"}` — REQUIRED for categories
- Omit the ACTION line entirely if no action fits
```

LLMs pattern-match the visible format examples more reliably than prose rules. The format-list addition is what actually changes selection behavior.

**2. Add two category-awareness guideline bullets**

Inserted after the existing guidelines:

```
- Some entries are **action categories** that group related actions (e.g. "Inventory", "Economy"). Selecting a category triggers a follow-up to pick the specific action within it.
- **REQUIRED**: When selecting a category, you MUST include `PARAMS: {"intent": "..."}` describing what you intend to do. Example: `ACTION: Economy PARAMS: {"intent": "sell a health potion to the player for 450 gold"}`. Category selections without intent will fail.
```

Same rule wording structure as the equivalent block landed in `native_action_selector.prompt` via #356, adapted to the embedded mode's lighter format.

## Test plan

1. **Category routing baseline (before PR):** With a plugin-defined category in the eligible-actions list, trigger embedded action emission via dialogue that should hit that category. LLM picks the category but emits either no PARAMS or schema-shaped fake params (e.g. `PARAMS: {"itemName": "Mead", "target": "Aevar"}` for an `Items` category). Engine fails to route.

2. **Category routing after PR:** Same trigger. LLM emits `ACTION: CategoryName PARAMS: {"intent": "..."}`. Engine routes to drilldown with intent populated.

3. **Direct-action regression check:** With only direct actions in the eligible list, trigger embedded action emission. Both before and after PR: LLM emits `ACTION: ActionName PARAMS: {schema-derived}` correctly. The category guidelines and format example are no-ops when no categories are present.

## Non-breaking

- No new variables or decorators referenced.
- No engine changes.
- Only modifies the embedded-actions submodule; selector, drilldown, and other prompts unchanged.
- Action YAMLs without categories see no behavioral change — the additions are about category cases that today fail silently.