### PR TITLE
Remove instruction to talk about surroundings

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0150_environmental_awareness.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0150_environmental_awareness.prompt
@@ -1,5 +1,3 @@
 {% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" %}
-{% if has_current_scene_description() or has_current_location_description() %}
-Reference your surroundings naturally when relevant. Don't force environmental details where they don't fit.
-{% endif %}
+
 {% endif %}


### PR DESCRIPTION
Change recommended by Gonçalo.

The AI seems to have difficulty judging "when relevant," leading to NPCs frequently commenting on the "cold stone floor" unnaturally, especially when using NSFW mods. I've also seen this reported frequently in NSFW channels.

This PR removes the instruction. Environmental data remains in the prompt - this just removes the instruction that the AI needs to comment on it "when relevant."

## Testing Done
None by me. 😅 