### PR TITLE
prompts/player_dialogue_target_selector: tighten guard, lean system, restructure factors

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/target_selectors/player_dialogue_target_selector.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/target_selectors/player_dialogue_target_selector.prompt
@@ -1,5 +1,5 @@
 [ system ]
-You are an AI decision-maker for Skyrim, determining which NPCs the player is addressing and who should respond. You analyze the player's input, nearby NPCs, and recent context to determine conversation targets and participants.
+Determine which NPC the player is addressing and who should respond. Analyze the player's input, nearby NPCs, and recent context.
 {{ get_scene_context(player.UUID, 0, "target_selection")}}
 [ end system ]
 
@@ -9,53 +9,43 @@ You are an AI decision-maker for Skyrim, determining which NPCs the player is ad
 - **Type**: {{ triggeringEvent.type }}
 - **Data**: {{ format_event(triggeringEvent, "verbose") }}
 
-{% if crosshairTarget %}
+{% if crosshairTarget and crosshairTarget.UUID and crosshairTarget.UUID != 0 %}
 {{ "## Player's Crosshair Target" }}
-The player is currently looking directly at: {{ crosshairTarget.name }} ({{ units_to_meters(crosshairTarget.distance) }} meters away)
+The player is looking directly at: **{{ crosshairTarget.name }}** ({{ units_to_meters(crosshairTarget.distance) }}m away)
 {% endif %}
 
 {{ "## Recent Dialogue" }}
 {{ render_template("components\\event_history_compact") }}
 
 {{ "## Instructions" }}
-First, analyze the player's dialogue and determine what type of interaction this is:
-1. Is the player directly speaking to a specific NPC?
-2. Is the player trying to get one NPC to talk to another NPC? (e.g., "What do you think about him?" or "Ask her about...")
-3. Is the player prompting a group discussion or asking an NPC to address everyone?
-4. Favor NPCs who are closer to the player or the ongoing situation. This is a very strong factor.
-{% if crosshairTarget %}
-5. The player currently has {{ crosshairTarget.name }} in their crosshair - this is a strong indicator that they may be addressing {{ decnpc(crosshairTarget.UUID).objectivePronoun }}.
+Determine the interaction type:
+1. **Direct address**: Player is speaking to a specific NPC (by name, pronoun, or context).
+2. **NPC-to-NPC prompt**: Player wants one NPC to talk to another (e.g., "What do you think about him?" or "Ask her about...").
+3. **Group address**: Player is speaking to everyone nearby or prompting group discussion.
+
+**Selection factors** (strongest first):
+{% if crosshairTarget and crosshairTarget.UUID and crosshairTarget.UUID != 0 %}
+- **Crosshair target**: The player is looking at {{ crosshairTarget.name }} — strong indicator they're addressing {{ decnpc(crosshairTarget.UUID).objectivePronoun }}.
 {% endif %}
+- **Name/reference**: Does the player's dialogue directly name or reference a specific NPC?
+- **Distance**: Strongly favor NPCs closer to the player. This is a very strong factor.
+- **Recent interaction**: Has the player recently been talking to a specific NPC? Ongoing conversations should continue naturally.
+- **Role match**: Does the dialogue content match an NPC's background, role, or recent actions?
+
+**For NPC-to-NPC dialogue**, determine:
+- Which NPC the player is primarily addressing (the speaker)
+- Which NPC they want that speaker to talk to (the target)
 
 Virtual NPC rules:
-- Regular NPCs cannot hear the speech of Virtual NPCs. Do not select an NPC to respond directly to a Virtual NPC.
-- Virtual NPCs may be selected as speaker but may NOT be selected as a target unless the speaker is also a Virtual NPC.
+- Regular NPCs cannot hear Virtual NPCs. Do not route dialogue from a Virtual NPC to a regular NPC.
+- Virtual NPCs may speak but may NOT be targeted unless the speaker is also Virtual.
 
-For direct player-to-NPC dialogue, determine the most likely target by considering:
-- Does the player's dialogue directly name or reference a specific NPC?
-- Has the player recently interacted with any of the nearby NPCs?
-- Is the player looking at or standing close to a particular NPC? Strongly consider distance as a factor in your decision.
-- Does the content of the dialogue match any NPC's background, role, or recent actions?
+If there is no clear target or the dialogue is general speech not directed at anyone, respond with `0`.
 
-For NPC-to-NPC dialogue prompted by the player, determine:
-- Which NPC is the player primarily addressing (who should speak)
-- Which other NPC they want that NPC to talk to (the target)
-- Is this a request for one NPC to comment on or address another?
+Output format:
+- `0` = No clear target
+- `Lydia>player` = Lydia speaks to the player
+- `Ulfric Stormcloak>Galmar Stone-Fist` = Ulfric speaks to Galmar
 
-If there is no clear interaction pattern or if the dialogue is general speech not directed at anyone, respond with "0".
-Respond with ONLY the following format:
-- If no clear target: "0"
-- For direct dialogue: "[speaking_npc_name]>player"
-- For NPC-to-NPC dialogue: "[speaking_npc_name]>[target_npc_name]"
-
-Where:
-- [speaking_npc_name] = the exact name of the NPC who will speak
-- [target_npc_name] = the exact name of another NPC who is being addressed
-
-Examples:
-- 0 = No clear dialogue target
-- Lydia>player = Lydia speaks directly to the player
-- Ulfric Stormcloak>Galmar Stone-Fist = Ulfric speaks to Galmar (player initiated this conversation)
-
-Important: Select the most realistic and natural interaction based on the player's words and game context.
+Output ONLY the result, nothing else.
 [ end user ]


### PR DESCRIPTION
Three small improvements to the player dialogue target selector prompt.

## 1. Defensive UUID check on `crosshairTarget`

```jinja
{% if crosshairTarget and crosshairTarget.UUID and crosshairTarget.UUID != 0 %}
```

The object can be set with `UUID == 0` for virtual or unresolved references; checking the UUID before using it prevents nonsensical "looking at something with no identity" lines from rendering.

## 2. Trim the system-message rephrasing

Drops:

> You are an AI decision-maker for Skyrim, determining which NPCs the player is addressing and who should respond. You analyze the player's input, nearby NPCs, and recent context to determine conversation targets and participants.

In favor of:

> Determine which NPC the player is addressing and who should respond. Analyze the player's input, nearby NPCs, and recent context.

Same content, ~30 fewer tokens per call. Across many dialogue beats per save, that adds up.

## 3. Restructure the Instructions section

The current version mixes two different categories of instructions inside one numbered list:

- *What type of interaction is this?* (direct / NPC-to-NPC / group)
- *How should candidates be weighted?* (distance, crosshair, etc.)

…and conditionally injects the crosshair note as item 5 inside that mixed list.

The new structure separates them:

- **Interaction type** — the three cases (direct address / NPC-to-NPC / group address) up top
- **Selection factors (strongest first)** — bulleted list ordered by strength: crosshair / name / distance / recent / role
- **For NPC-to-NPC dialogue** — sub-clause for that case
- **Virtual NPC rules** — unchanged
- **Output format** — unchanged

Reduces category confusion in the model's reasoning step. Especially noticeable on smaller models that benefit from explicit structure.

## Behavior

No behavior change for the wire format. Selection format and output format unchanged. The crosshair guard is the only logical-behavior change and it's strictly defensive — same output when `UUID` is valid, no nonsensical render when it isn't.

## Diff size

```
1 file changed, 31 insertions(+), 41 deletions(-)
```