### PR TITLE
fix: show full content for existing knowledge entries in agent prompt

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/agent_knowledge_builder.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/agent_knowledge_builder.prompt
@@ -93,9 +93,10 @@
 
     {% if agentContext and agentContext.existingEntries and agentContext.existingEntries|length > 0 %}
     <existing_proposals count="{{ agentContext.existingEntries|length }}">
-    These entries are already proposed in the UI. Consider them to avoid duplicates and maintain consistency.
+    These entries are already proposed in the UI. The full content is shown so you can preserve user-authored details (numbers, names, prices, specific phrasing) when updating an entry — never paraphrase or shorten content the user has set unless explicitly asked. When the user asks to modify an entry, rewrite the entire content with your changes applied on top of the existing text, keeping every other detail intact.
     {% for entry in agentContext.existingEntries %}
-    - [{{ entry.status }}] id={{ entry.id }} "{{ entry.data.display_name }}" — {{ entry.data.content | truncate(80) }}{% if entry.data.condition_expr %} (condition: {{ entry.data.condition_expr }}){% endif %}
+    - [{{ entry.status }}] id={{ entry.id }} display_name="{{ entry.data.display_name }}"{% if entry.data.condition_expr %} condition="{{ entry.data.condition_expr }}"{% endif %}
+      content: {{ entry.data.content }}
     {% endfor %}
     Use these IDs in the `entry_ids` parameter when updating or removing proposals.
     </existing_proposals>


### PR DESCRIPTION
## Summary

The knowledge-builder agent's prompt previously truncated each existing proposal's content to 80 characters and only said "consider them to avoid duplicates". When the user then asked the agent to modify an entry — e.g. "update the price to 50 coins" — the agent would rewrite the content from its own 80-char summary, losing whatever specific numbers, names, prices, or phrasing the user had originally authored.

## Change

- Show the **full content** for each existing entry instead of truncating to 80 chars.
- Add explicit guidance: when updating, rewrite the entire content with the requested changes applied on top of the existing text. Never paraphrase or shorten what the user has set unless explicitly asked.
- Move `id`, `display_name`, and `condition_expr` to a dedicated header line so the content can appear cleanly on its own line.

## Test plan

- [ ] In-game: create a knowledge entry with specific user-authored details (e.g. an exact price or NPC name list). Then ask the agent to make a small modification (e.g. "raise the price by 10"). Verify the agent's update preserves all the other details verbatim and only changes what was asked.
- [ ] Verify duplicate-avoidance behavior still works (the original purpose of showing existing entries).