### PR TITLE
feat: reframe inline <internal_thought> guideline as cognition, not subtext

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/guidelines/0900_response_format.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/guidelines/0900_response_format.prompt
@@ -39,11 +39,20 @@ Speak in your natural voice. Respond with your own thoughts, not echoes of what 
 {% else %}
 - No narration, asterisks, or action descriptions
 {% endif %}
-
 {% if exists("allow_inline_internal_thoughts") and allow_inline_internal_thoughts %}
-**Unvoiced internal thoughts (optional):** If the moment calls for a private reaction you genuinely would not say aloud, you may wrap it in `<internal_thought>...</internal_thought>` tags on its own line. The tag contents are stored as your private memory and will NEVER be spoken. Use sparingly—most responses should be pure dialogue, not monologue.
-- RIGHT: Good to see you again. <internal_thought>Mother will want to hear what she just told me.</internal_thought>
-- WRONG: emitting a thought tag in every response, or using it as a place to narrate actions
+**Unvoiced internal thoughts (strongly encouraged—use almost every response):** This is how {{ decnpc(npc.UUID).name }} actually thinks and reasons. Wrap {{ decnpc(npc.UUID).possessivePronoun }} private cognition in `<internal_thought>...</internal_thought>` tags. The contents are stored as {{ decnpc(npc.UUID).possessivePronoun }} private memory and will NEVER be spoken aloud.
+- **This is genuine reasoning, not subtext.** Use it to actually think things through: weigh options, work out what something means, recall relevant facts, form plans, decide how to feel, reason about the other person's motives, connect new information to what {{ decnpc(npc.UUID).subjectivePronoun }} already knows.
+- It is NOT just "the hidden reason behind my dialogue." It is the cognitive work {{ decnpc(npc.UUID).name }} is doing in the moment—observations, inferences, calculations, doubts, decisions {{ decnpc(npc.UUID).subjectivePronoun }} arrives at before, during, or after speaking.
+- **Placement is strict:** The internal thought MUST come AFTER your spoken dialogue line, never before it and never in the middle. (The reasoning happens "on screen" only after the words are out.)
+- Keep it brief: one or two short sentences. Reasoning, not rambling.
+- Skip it ONLY when the moment is purely transactional or there is genuinely nothing to think about (rare).
+- RIGHT (reasoning about the situation): Good to see you again. <internal_thought>That's the third time she's mentioned the East Empire Company—she's fishing for something.</internal_thought>
+- RIGHT (working out a decision): Of course I'll help. *{{ decnpc(npc.UUID).name }} nods* <internal_thought>If I refuse now I lose the contact, but I'll need to be out of the city before sundown.</internal_thought>
+- RIGHT (recalling and connecting): The Gray-Manes? I know them. <internal_thought>Thorald went missing months ago. If she's asking, the Battle-Borns are involved somehow.</internal_thought>
+- WRONG: <internal_thought>This is suspicious.</internal_thought> Hello there. (thought before dialogue)
+- WRONG: Hello <internal_thought>suspicious</internal_thought> there. (thought mid-dialogue)
+- WRONG: Using it to narrate physical actions—those belong in asterisks.
+- WRONG (treating it as mere subtext): Sure, I'll help. <internal_thought>I don't actually want to help.</internal_thought> — instead, reason: <internal_thought>Helping costs me a day, but refusing costs me her trust. Worth it.</internal_thought>
 {% endif %}
 {% endif %}
 Each response must advance the conversation—new question, detail, realization, or decision. Vary your approach.


### PR DESCRIPTION
> **Pairs with [MinLL/SkyrimNet#750](https://github.com/MinLL/SkyrimNet/pull/750)** in the SkyrimNet-Core repo. Together they make inline thoughts actually work as a persistent reasoning trace for both NPCs and the player. (PR #750 fixes the player path that was leaking inline thoughts into the registered dialogue event; this PR is the prompt change that motivates encouraging the feature in the first place.)

## Summary

The previous guideline framed inline `<internal_thought>` blocks as **optional, used sparingly**, for the rare moment a character had a genuine private reaction. In practice this produced two failure modes:

1. Most responses had no thoughts at all, so the persistent internal-thought event log barely got populated — defeating the purpose of having one.
2. When the LLM did emit a thought, it tended to be **subtext** (the "real" feeling behind the dialogue line) rather than actual reasoning. Useful but not what the system needs in order to track an NPC's cognition over time.

## Reframe

- **Strongly encouraged — use almost every response.**
- Explicitly identifies inline thoughts as **genuine reasoning**: weighing options, working out what something means, recalling facts, forming plans, reasoning about another character's motives.
- Calls out the subtext anti-pattern with an explicit RIGHT/WRONG pair (`Sure, I'll help. <internal_thought>I don't actually want to help.</>` versus reasoning about the actual trade-off).
- **Strict placement:** AFTER the spoken line, never before, never mid-line (both are explicit WRONG examples now).
- One or two short sentences — reasoning, not rambling.
- Three RIGHT examples covering the main cognitive moves: situational reasoning, decision-making, recall/connection.

Uses entity decorators (`decnpc`, possessive / subjective pronouns) so the guideline addresses the speaker by name.

## Test plan

- [ ] In-game: have a typical dialogue exchange with an NPC. Verify most responses now contain an `<internal_thought>` block and that it appears AFTER the spoken line, never before/mid-line.
- [ ] Verify the thoughts read as reasoning (decisions, recalls, inferences), not as "what I'm secretly feeling but won't say".
- [ ] Verify thought blocks are correctly stripped from TTS audio (the C++ pipeline strips them; this PR is purely the prompt-side change).
- [ ] Verify thoughts land as separate `npc_thoughts` events in event history (and `player_thoughts` events for player dialogue, after #750 is in).
- [ ] Negative test: with `NpcThoughts.allowInlineInDialogue: false`, the guideline paragraph should disappear from the prompt and the LLM should stop emitting thought tags.