### PR TITLE
prompts: knowledge-builder truncate fix + move response_format to user_final_instructions

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/agent_knowledge_builder.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/agent_knowledge_builder.prompt
@@ -95,7 +95,7 @@
     <existing_proposals count="{{ agentContext.existingEntries|length }}">
     These entries are already proposed in the UI. Consider them to avoid duplicates and maintain consistency.
     {% for entry in agentContext.existingEntries %}
-    - [{{ entry.status }}] id={{ entry.id }} "{{ entry.data.display_name }}" — {{ entry.data.content | truncate(80) }}{% if entry.data.condition_expr %} (condition: {{ entry.data.condition_expr }}){% endif %}
+    - [{{ entry.status }}] id={{ entry.id }} "{{ entry.data.display_name }}" — {{ entry.data.content }}{% if entry.data.condition_expr %} (condition: {{ entry.data.condition_expr }}){% endif %}
     {% endfor %}
     Use these IDs in the `entry_ids` parameter when updating or removing proposals.
     </existing_proposals>

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0500_response_format.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0500_response_format.prompt
@@ -1,4 +1,4 @@
-## Response Format
+# Response Format
 No headers or labels in your output—just the response itself.
 {% if render_mode == "thoughts" or render_mode == "book" %}
 Output {{ decnpc(npc.UUID).name }}'s silent inner monologue—not spoken aloud.
@@ -39,11 +39,20 @@ Speak in your natural voice. Respond with your own thoughts, not echoes of what 
 {% else %}
 - No narration, asterisks, or action descriptions
 {% endif %}
-
 {% if exists("allow_inline_internal_thoughts") and allow_inline_internal_thoughts %}
-**Unvoiced internal thoughts (optional):** If the moment calls for a private reaction you genuinely would not say aloud, you may wrap it in `<internal_thought>...</internal_thought>` tags on its own line. The tag contents are stored as your private memory and will NEVER be spoken. Use sparingly—most responses should be pure dialogue, not monologue.
-- RIGHT: Good to see you again. <internal_thought>Mother will want to hear what she just told me.</internal_thought>
-- WRONG: emitting a thought tag in every response, or using it as a place to narrate actions
+**Unvoiced internal thoughts (strongly encouraged—use almost every response):** This is how {{ decnpc(npc.UUID).name }} actually thinks and reasons. Wrap {{ decnpc(npc.UUID).possessivePronoun }} private cognition in `<internal_thought>...</internal_thought>` tags. The contents are stored as {{ decnpc(npc.UUID).possessivePronoun }} private memory and will NEVER be spoken aloud.
+- **This is genuine reasoning, not subtext.** Use it to actually think things through: weigh options, work out what something means, recall relevant facts, form plans, decide how to feel, reason about the other person's motives, connect new information to what {{ decnpc(npc.UUID).subjectivePronoun }} already knows.
+- It is NOT just "the hidden reason behind my dialogue." It is the cognitive work {{ decnpc(npc.UUID).name }} is doing in the moment—observations, inferences, calculations, doubts, decisions {{ decnpc(npc.UUID).subjectivePronoun }} arrives at before, during, or after speaking.
+- **Placement is strict:** The internal thought MUST come AFTER your spoken dialogue line, never before it and never in the middle. (The reasoning happens "on screen" only after the words are out.)
+- Keep it brief: one or two short sentences. Reasoning, not rambling.
+- Skip it ONLY when the moment is purely transactional or there is genuinely nothing to think about (rare).
+- RIGHT (reasoning about the situation): Good to see you again. <internal_thought>That's the third time she's mentioned the East Empire Company—she's fishing for something.</internal_thought>
+- RIGHT (working out a decision): Of course I'll help. *{{ decnpc(npc.UUID).name }} nods* <internal_thought>If I refuse now I lose the contact, but I'll need to be out of the city before sundown.</internal_thought>
+- RIGHT (recalling and connecting): The Gray-Manes? I know them. <internal_thought>Thorald went missing months ago. If she's asking, the Battle-Borns are involved somehow.</internal_thought>
+- WRONG: <internal_thought>This is suspicious.</internal_thought> Hello there. (thought before dialogue)
+- WRONG: Hello <internal_thought>suspicious</internal_thought> there. (thought mid-dialogue)
+- WRONG: Using it to narrate physical actions—those belong in asterisks.
+- WRONG (treating it as mere subtext): Sure, I'll help. <internal_thought>I don't actually want to help.</internal_thought> — instead, reason: <internal_thought>Helping costs me a day, but refusing costs me her trust. Worth it.</internal_thought>
 {% endif %}
 {% endif %}
 Each response must advance the conversation—new question, detail, realization, or decision. Vary your approach.

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0500_response_format.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0500_response_format.prompt
@@ -47,11 +47,13 @@ Speak in your natural voice. Respond with your own thoughts, not echoes of what 
 - Keep it brief: one or two short sentences. Reasoning, not rambling.
 - Skip it ONLY when the moment is purely transactional or there is genuinely nothing to think about (rare).
 - RIGHT (reasoning about the situation): Good to see you again. <internal_thought>That's the third time she's mentioned the East Empire Company—she's fishing for something.</internal_thought>
-- RIGHT (working out a decision): Of course I'll help. *{{ decnpc(npc.UUID).name }} nods* <internal_thought>If I refuse now I lose the contact, but I'll need to be out of the city before sundown.</internal_thought>
+- RIGHT (working out a decision): Of course I'll help.{% if is_narration_enabled() %} *{{ decnpc(npc.UUID).name }} nods*{% endif %} <internal_thought>If I refuse now I lose the contact, but I'll need to be out of the city before sundown.</internal_thought>
 - RIGHT (recalling and connecting): The Gray-Manes? I know them. <internal_thought>Thorald went missing months ago. If she's asking, the Battle-Borns are involved somehow.</internal_thought>
 - WRONG: <internal_thought>This is suspicious.</internal_thought> Hello there. (thought before dialogue)
 - WRONG: Hello <internal_thought>suspicious</internal_thought> there. (thought mid-dialogue)
+{% if is_narration_enabled() %}
 - WRONG: Using it to narrate physical actions—those belong in asterisks.
+{% endif %}
 - WRONG (treating it as mere subtext): Sure, I'll help. <internal_thought>I don't actually want to help.</internal_thought> — instead, reason: <internal_thought>Helping costs me a day, but refusing costs me her trust. Worth it.</internal_thought>
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Two prompt fixes bundled into one PR.

## 1. Drop unsupported `truncate(80)` filter from knowledge-builder existing-proposals block

`agent_knowledge_builder.prompt` was rendering `{{ entry.data.content | truncate(80) }}` for each existing proposal. The Inja-style `truncate` filter is **not registered** in the C++ template engine, so the expression was falling through to the LLM as **literal unrendered text** — the agent would see its own existing entries' content as the placeholder string itself instead of the actual content, then refuse to update entries (or fall back to `list_world_knowledge` MCP calls) because it couldn't read what was already there.

Drop the unsupported filter; render `{{ entry.data.content }}` directly. The full content is now visible to the agent. (No truncation in C++ template space; if a length cap is ever needed, register it as a real Inja filter or do the truncation in the JS layer that builds `agentContext`.)

## 2. Move `response_format` from `guidelines` (system_head) to `user_final_instructions` + reframe inline-thoughts guideline as cognition

The response-format guideline was being rendered inside the `system_head` block via the `guidelines` submodule. Moving it to `user_final_instructions` puts it at the end of the user turn — closer to the model's output position and harder to drift away from across long event histories. File renamed from `submodules/guidelines/0900_response_format.prompt` to `submodules/user_final_instructions/0500_response_format.prompt`. Top-level heading changed from `##` to `#` to match the heading depth expected of user-final-instruction submodules.

While the file is being moved, the inline `<internal_thought>` paragraph is also reworked:

- **From "optional, used sparingly" → "strongly encouraged, use almost every response."** The previous framing produced two failure modes: most responses had no thoughts at all (so the persistent thought event log was barely populated), and when the LLM did emit a thought it tended to be **subtext** rather than reasoning.
- **Re-anchored as genuine cognition** (weighing options, recalling facts, reasoning about motives) rather than subtext (the hidden reason behind what was said). New explicit RIGHT/WRONG pair calls out the subtext anti-pattern.
- **Strict placement:** AFTER the spoken line, never before, never mid-line. Both bad placements are now explicit WRONG examples.
- One or two short sentences — reasoning, not rambling.
- Three RIGHT examples covering situational reasoning, decision-making, and recall/connection.
- Uses entity decorators (`decnpc.name`, possessive / subjective pronouns) so the guideline addresses the speaker by name.

Pairs with [MinLL/SkyrimNet#750](https://github.com/MinLL/SkyrimNet/pull/750) on the C++ side, which fixes the player path that was leaking inline thoughts into the registered dialogue event. Together they make inline thoughts actually work as a persistent reasoning trace for both NPCs and the player.

## Test plan

**Knowledge builder (fix 1):**
- [x] Open the Knowledge Builder UI for a pack that already has at least one entry. Ask the agent to update one of those entries (e.g. "raise the price on X by 10"). Verify the agent reads the existing content correctly and modifies only what was asked, instead of saying it cannot see the content / falling back to MCP tool calls.

**Response-format move + inline-thoughts (fix 2):**
- [x] Confirm `submodules/guidelines/0900_response_format.prompt` is gone and `submodules/user_final_instructions/0500_response_format.prompt` is loaded in its place. The composed prompt should still contain a `# Response Format` section, just at the end of the user turn instead of in the system block.
- [x] In-game: have a typical dialogue exchange with an NPC. Verify most responses now contain an `<internal_thought>` block AFTER the spoken line, never before/mid-line.
- [x] Verify the thoughts read as reasoning (decisions, recalls, inferences), not as "what I'm secretly feeling but won't say".
- [x] Verify thought blocks are stripped from TTS audio and land as separate `npc_thoughts` events in event history (and `player_thoughts` events for player dialogue, after #750 is in).
- [ ] Negative test: with `NpcThoughts.allowInlineInDialogue: false`, the guideline paragraph should disappear from the prompt and the LLM should stop emitting thought tags.