### PR TITLE
fix: forbid <thinking> reasoning tags in response format

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0500_response_format.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0500_response_format.prompt
@@ -57,4 +57,5 @@ Speak in your natural voice. Respond with your own thoughts, not echoes of what 
 - WRONG (treating it as mere subtext): Sure, I'll help. <internal_thought>I don't actually want to help.</internal_thought> — instead, reason: <internal_thought>Helping costs me a day, but refusing costs me her trust. Worth it.</internal_thought>
 {% endif %}
 {% endif %}
+**Never emit `<thinking>...</thinking>` or any other reasoning/scratchpad tag.** Those are model-internal reasoning conventions and are not part of the in-character response—if any survive into the output they get spoken aloud by TTS. Output only the in-character text{% if exists("allow_inline_internal_thoughts") and allow_inline_internal_thoughts %} (plus `<internal_thought>` blocks per the rules above){% endif %}.
 Each response must advance the conversation—new question, detail, realization, or decision. Vary your approach.


### PR DESCRIPTION
## Summary

- Adds an unconditional rule to `submodules/user_final_instructions/0500_response_format.prompt` telling models never to emit `<thinking>...</thinking>` or any other reasoning/scratchpad tag.
- Some LLMs (DeepSeek-R1, QwQ family) emit reasoning in `<thinking>` blocks despite system instructions; when only the close tag survives stream chunking, the model's reasoning gets spoken aloud by TTS. Field-observed on a bandit in active combat: `"Let me craft a short, urgent combat response. </thinking> Not... not yet...!"`
- Rule is placed outside the `allow_inline_internal_thoughts` conditional so it applies regardless of render mode (combat NPCs typically have internal thoughts off; that's exactly when this leak happens).
- Cross-references `<internal_thought>` as the canonical tag for private cognition when the flag is on.

Companion to **MinLL/SkyrimNet#752** (skyrimnet-core), which adds defense-in-depth `StripThinkingTags` at the TTS path and the inline-thought registration path. The two changes together prevent reasoning leaks at both the prompt and post-processing layers.

## Test plan

- [ ] Smoke: in-game with a `<thinking>`-prone model (e.g. DeepSeek-R1 via OpenRouter), trigger NPC dialogue and confirm no `<thinking>` blocks appear in the LLM response. (The skyrimnet-core companion strips them post-hoc as defense-in-depth, but this PR aims to suppress them at the source.)
- [ ] Visual diff of the rendered prompt for a few render modes to confirm placement: combat NPC (internal_thoughts off), conversational NPC (internal_thoughts on), thoughts/book modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)