### PR TITLE
feat: add Listen In Illusion spell; rename free Eavesdrop to debug power

### DIFF
--- a/Source/Scripts/skynet_McmScript.psc
+++ b/Source/Scripts/skynet_McmScript.psc
@@ -6,6 +6,10 @@ skynet_Library library
 Perk Property TelepathyPerk Auto
 Perk Property TelepathyCanonicalPerk Auto
 Spell Property TelepathyEavesdropSpell Auto
+{Lesser Power debug toggle. Property name kept stable for save compat — the
+ underlying form (0012E0) is now the "Eavesdrop (Debug)" lesser power.}
+Spell Property TelepathyListenInSpell Auto
+{Adept Illusion spell with a 60s duration. Auto-disables eavesdropping on expire.}
 
 int toggleShowWebUi
 int toggleInGameHotkeys
@@ -17,6 +21,8 @@ int optionAddTelepathyCanonicalPerk
 int optionRemoveTelepathyCanonicalPerk
 int optionAddTelepathyEavesdropSpell
 int optionRemoveTelepathyEavesdropSpell
+int optionAddTelepathyListenInSpell
+int optionRemoveTelepathyListenInSpell
 
 ; Track current MCM page locally — workaround for save-data instances where
 ; SKI_ConfigBase's `CurrentPage` auto-property backing variable
@@ -329,9 +335,10 @@ function DisplayPowers()
 
     Actor playerRef = Game.GetPlayer()
 
-    bool hasBasic     = playerRef.HasPerk(TelepathyPerk)
-    bool hasCanonical = playerRef.HasPerk(TelepathyCanonicalPerk)
-    bool hasSpell     = playerRef.HasSpell(TelepathyEavesdropSpell)
+    bool hasBasic       = playerRef.HasPerk(TelepathyPerk)
+    bool hasCanonical   = playerRef.HasPerk(TelepathyCanonicalPerk)
+    bool hasDebugPower  = playerRef.HasSpell(TelepathyEavesdropSpell)
+    bool hasListenIn    = playerRef.HasSpell(TelepathyListenInSpell)
 
     ; --- Telepathy (basic) ---
     AddHeaderOption("Telepathy")
@@ -367,21 +374,38 @@ function DisplayPowers()
         optionRemoveTelepathyCanonicalPerk = AddTextOption("Remove", "", OPTION_FLAG_DISABLED)
     endif
 
-    ; --- Telepathy: Eavesdrop spell ---
-    AddHeaderOption("Telepathy: Eavesdrop")
+    ; --- Telepathy: Eavesdrop (Debug) lesser power ---
+    AddHeaderOption("Telepathy: Eavesdrop (Debug)")
     AddHeaderOption("")
-    if hasSpell
-        AddTextOption("Spell", "Owned")
+    if hasDebugPower
+        AddTextOption("Power", "Owned")
     else
-        AddTextOption("Spell", "Not owned")
+        AddTextOption("Power", "Not owned")
     endif
     AddEmptyOption()
-    if hasSpell
+    if hasDebugPower
         optionAddTelepathyEavesdropSpell    = AddTextOption("Add", "", OPTION_FLAG_DISABLED)
         optionRemoveTelepathyEavesdropSpell = AddTextOption("Remove", "")
     else
         optionAddTelepathyEavesdropSpell    = AddTextOption("Add", "")
         optionRemoveTelepathyEavesdropSpell = AddTextOption("Remove", "", OPTION_FLAG_DISABLED)
+    endif
+
+    ; --- Telepathy: Listen In spell (timed Illusion spell) ---
+    AddHeaderOption("Telepathy: Listen In")
+    AddHeaderOption("")
+    if hasListenIn
+        AddTextOption("Spell", "Owned")
+    else
+        AddTextOption("Spell", "Not owned")
+    endif
+    AddEmptyOption()
+    if hasListenIn
+        optionAddTelepathyListenInSpell    = AddTextOption("Add", "", OPTION_FLAG_DISABLED)
+        optionRemoveTelepathyListenInSpell = AddTextOption("Remove", "")
+    else
+        optionAddTelepathyListenInSpell    = AddTextOption("Add", "")
+        optionRemoveTelepathyListenInSpell = AddTextOption("Remove", "", OPTION_FLAG_DISABLED)
     endif
 
 endfunction
@@ -782,6 +806,16 @@ function HandlePowersOptionSelect(int option)
             playerRef.RemoveSpell(TelepathyEavesdropSpell)
         endif
         ForcePageReset()
+    elseif option == optionAddTelepathyListenInSpell
+        if !playerRef.HasSpell(TelepathyListenInSpell)
+            playerRef.AddSpell(TelepathyListenInSpell, False)
+        endif
+        ForcePageReset()
+    elseif option == optionRemoveTelepathyListenInSpell
+        if playerRef.HasSpell(TelepathyListenInSpell)
+            playerRef.RemoveSpell(TelepathyListenInSpell)
+        endif
+        ForcePageReset()
     endif
 
 endfunction
@@ -807,7 +841,9 @@ function HandlePowersOptionHighlight(int option)
     elseif option == optionRemoveTelepathyCanonicalPerk
         SetInfoText("Removes Canonical Telepathy only. Basic Telepathy stays held — you'll continue to perceive NPC thoughts in the chat / Eavesdrop spell. Your character will stop being treated as in-fiction telepathic by the LLM.")
     elseif option == optionAddTelepathyEavesdropSpell || option == optionRemoveTelepathyEavesdropSpell
-        SetInfoText("Telepathy: Eavesdrop is a Lesser Power that toggles TTS voicing of nearby NPC thoughts on or off. The toggle resets to OFF every game load. Casting it without any Telepathy perk does nothing audible (perception is gated). Voiced thoughts use the NPC's normal voice with a thought-style audio effect overlay, and subtitles wrap the thought with ~tildes~ so you can tell it apart from spoken dialogue.")
+        SetInfoText("Telepathy: Eavesdrop (Debug) is a free Lesser Power that toggles TTS voicing of nearby NPC thoughts on or off — provided for testing. The toggle resets to OFF every game load. Casting it without any Telepathy perk does nothing audible (perception is gated). For in-fiction use, prefer the Telepathy: Listen In spell below — it is an Illusion spell with a real magicka cost and 60-second duration. Note that casting Listen In and waiting it out will force eavesdropping OFF when it expires, even if you had it ON via this debug power.")
+    elseif option == optionAddTelepathyListenInSpell || option == optionRemoveTelepathyListenInSpell
+        SetInfoText("Telepathy: Listen In is an instant Illusion spell (base 140 magicka, no cast time, silent, non-hostile) that activates Telepathy eavesdropping for 60 seconds. Magicka cost is discounted by standard Illusion perks (Apprentice / Adept / Novice Illusion etc.). When the duration expires, eavesdropping is forced OFF — including overriding the debug toggle if it was previously on. Voiced thoughts use the NPC's normal voice with a thought-style audio effect overlay, and subtitles wrap the thought with ~tildes~ so you can tell it apart from spoken dialogue.")
     endif
 
 endfunction

--- a/Source/Scripts/skynet_TelepathyListenIn.psc
+++ b/Source/Scripts/skynet_TelepathyListenIn.psc
@@ -1,0 +1,16 @@
+Scriptname skynet_TelepathyListenIn extends ActiveMagicEffect
+{Drives the timed Telepathy: Listen In spell. Enables Telepathy eavesdropping on cast and forces it OFF when the duration expires. If the player had eavesdropping ON via the debug Lesser Power before casting, expiry of this effect will turn it off — that's documented in the MCM tooltip for the debug power.}
+
+Event OnEffectStart(Actor akTarget, Actor akCaster)
+
+    SkyrimNetApi.SetTelepathyEavesdroppingEnabled(true)
+    Debug.Notification("Telepathy: Listen In ON (60s)")
+
+EndEvent
+
+Event OnEffectFinish(Actor akTarget, Actor akCaster)
+
+    SkyrimNetApi.SetTelepathyEavesdroppingEnabled(false)
+    Debug.Notification("Telepathy: Listen In expired")
+
+EndEvent

--- a/plugins/SkyrimNet/MagicEffects/skynet_TelepathyEavesdropDebugMagicEffect - 0012DF_SkyrimNet.esp.json
+++ b/plugins/SkyrimNet/MagicEffects/skynet_TelepathyEavesdropDebugMagicEffect - 0012DF_SkyrimNet.esp.json
@@ -1,0 +1,33 @@
+{
+  "FormKey": "0012DF:SkyrimNet.esp",
+  "EditorID": "skynet_TelepathyEavesdropDebugMagicEffect",
+  "VirtualMachineAdapter": {
+    "Scripts": [
+      {
+        "Name": "skynet_TelepathyEavesdrop"
+      }
+    ]
+  },
+  "Name": {
+    "TargetLanguage": "English",
+    "Value": "SkyrimNet Telepathy Eavesdrop (Debug)"
+  },
+  "MenuDisplayObject": "0435A5:Skyrim.esm",
+  "Flags": [
+    "NoDuration",
+    "NoArea",
+    "Painless"
+  ],
+  "Archetype": {
+    "MutagenObjectType": "MagicEffectArchetype",
+    "Type": "Script"
+  },
+  "CastType": "FireAndForget",
+  "DualCastScale": 1.0,
+  "CastingSoundLevel": "Normal",
+  "Sounds": [],
+  "Description": {
+    "TargetLanguage": "English",
+    "Value": ""
+  }
+}

--- a/plugins/SkyrimNet/MagicEffects/skynet_TelepathyListenInMagicEffect - 0012E1_SkyrimNet.esp.json
+++ b/plugins/SkyrimNet/MagicEffects/skynet_TelepathyListenInMagicEffect - 0012E1_SkyrimNet.esp.json
@@ -1,20 +1,19 @@
 {
-  "FormKey": "0012DF:SkyrimNet.esp",
-  "EditorID": "skynet_TelepathyEavesdropMagicEffect",
+  "FormKey": "0012E1:SkyrimNet.esp",
+  "EditorID": "skynet_TelepathyListenInMagicEffect",
   "VirtualMachineAdapter": {
     "Scripts": [
       {
-        "Name": "skynet_TelepathyEavesdrop"
+        "Name": "skynet_TelepathyListenIn"
       }
     ]
   },
   "Name": {
     "TargetLanguage": "English",
-    "Value": "SkyrimNet Telepathy Eavesdrop"
+    "Value": "SkyrimNet Telepathy Listen In"
   },
   "MenuDisplayObject": "0435A5:Skyrim.esm",
   "Flags": [
-    "NoDuration",
     "NoArea",
     "Painless"
   ],
@@ -22,9 +21,12 @@
     "MutagenObjectType": "MagicEffectArchetype",
     "Type": "Script"
   },
+  "MagicSkill": "Illusion",
+  "ResistValue": "ResistMagic",
+  "BaseCost": 1.63,
   "CastType": "FireAndForget",
   "DualCastScale": 1.0,
-  "CastingSoundLevel": "Normal",
+  "CastingSoundLevel": "Silent",
   "Sounds": [],
   "Description": {
     "TargetLanguage": "English",

--- a/plugins/SkyrimNet/Quests/skynet_Mcm - 000D63_SkyrimNet.esp.json
+++ b/plugins/SkyrimNet/Quests/skynet_Mcm - 000D63_SkyrimNet.esp.json
@@ -25,6 +25,11 @@
             "MutagenObjectType": "ScriptObjectProperty",
             "Name": "TelepathyEavesdropSpell",
             "Object": "0012E0:SkyrimNet.esp"
+          },
+          {
+            "MutagenObjectType": "ScriptObjectProperty",
+            "Name": "TelepathyListenInSpell",
+            "Object": "0012E2:SkyrimNet.esp"
           }
         ]
       }

--- a/plugins/SkyrimNet/Spells/skynet_TelepathyEavesdropDebugPower - 0012E0_SkyrimNet.esp.json
+++ b/plugins/SkyrimNet/Spells/skynet_TelepathyEavesdropDebugPower - 0012E0_SkyrimNet.esp.json
@@ -1,9 +1,9 @@
 {
   "FormKey": "0012E0:SkyrimNet.esp",
-  "EditorID": "skynet_TelepathyEavesdropSpell",
+  "EditorID": "skynet_TelepathyEavesdropDebugPower",
   "Name": {
     "TargetLanguage": "English",
-    "Value": "Telepathy: Eavesdrop"
+    "Value": "Telepathy: Eavesdrop (Debug)"
   },
   "MenuDisplayObject": "0435A5:Skyrim.esm",
   "EquipmentType": "025BEE:Skyrim.esm",

--- a/plugins/SkyrimNet/Spells/skynet_TelepathyListenInSpell - 0012E2_SkyrimNet.esp.json
+++ b/plugins/SkyrimNet/Spells/skynet_TelepathyListenInSpell - 0012E2_SkyrimNet.esp.json
@@ -1,0 +1,28 @@
+{
+  "FormKey": "0012E2:SkyrimNet.esp",
+  "EditorID": "skynet_TelepathyListenInSpell",
+  "Name": {
+    "TargetLanguage": "English",
+    "Value": "Telepathy: Listen In"
+  },
+  "MenuDisplayObject": "0435A5:Skyrim.esm",
+  "EquipmentType": "025BEE:Skyrim.esm",
+  "Description": {
+    "TargetLanguage": "English",
+    "Value": "Listen in on the thoughts of those nearby for 60 seconds. Cast is instant and silent. Affected by Illusion perks for magicka discount."
+  },
+  "Type": "Spell",
+  "CastType": "FireAndForget",
+  "ChargeTime": 0.0,
+  "CastDuration": 0.0,
+  "Effects": [
+    {
+      "BaseEffect": "0012E1:SkyrimNet.esp",
+      "Data": {
+        "Magnitude": 1.0,
+        "Area": 0,
+        "Duration": 60
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Stacked on **`feat/telepathy-system`** — merge that first.

Adds an in-fiction timed Illusion spell so the eavesdrop toggle has a real magicka-gated option, and relabels the existing free Lesser Power as a debug toggle.

### New: `Telepathy: Listen In` (FormKey `0012E2`)
- **Type**: Spell (consumes magicka).
- **Cost**: Base 140 magicka via the effect's `BaseCost` (1.63) × Skyrim's standard `magnitude^1.1 × duration^1.1` formula. Discounted by Illusion perks because the magic effect's `MagicSkill` is Illusion.
- **Cast**: instant (`ChargeTime 0`, FireAndForget), silent (`CastingSoundLevel: Silent`, no sounds), non-hostile (`Painless` flag).
- **Duration**: 60 seconds.
- **`OnEffectStart`** → `SkyrimNetApi.SetTelepathyEavesdroppingEnabled(true)`.
- **`OnEffectFinish`** → forces it OFF, even if the debug toggle had it on. Documented in both MCM tooltips so the override isn't surprising.

### Renamed: existing `skynet_TelepathyEavesdropSpell` → debug power
- FormKey `0012E0` unchanged for save compatibility.
- EditorID: `skynet_TelepathyEavesdropSpell` → `skynet_TelepathyEavesdropDebugPower`.
- Display: \"Telepathy: Eavesdrop\" → \"Telepathy: Eavesdrop (Debug)\".
- Magic effect renamed in parallel (FormKey `0012DF` unchanged).
- File names renamed via \`git mv\` to match the new EditorIDs (Spriggit filename convention).
- Papyrus property name \`TelepathyEavesdropSpell\` deliberately kept stable in scripts/quest JSON so existing saves' bindings still resolve.

### MCM Powers page
- Both options listed with Add/Remove pairs (debug power + Listen In).
- New section \"Telepathy: Listen In\".
- Debug-power tooltip now recommends Listen In for in-fiction use and warns that Listen In's expiry forces eavesdropping off.

## Files

- `plugins/SkyrimNet/MagicEffects/skynet_TelepathyListenInMagicEffect - 0012E1_SkyrimNet.esp.json` (new)
- `plugins/SkyrimNet/Spells/skynet_TelepathyListenInSpell - 0012E2_SkyrimNet.esp.json` (new)
- `Source/Scripts/skynet_TelepathyListenIn.psc` (new)
- `plugins/SkyrimNet/MagicEffects/skynet_TelepathyEavesdrop{Magic → DebugMagic}Effect - 0012DF*.json` (renamed + display name)
- `plugins/SkyrimNet/Spells/skynet_TelepathyEavesdrop{Spell → DebugPower} - 0012E0*.json` (renamed + display name)
- `plugins/SkyrimNet/Quests/skynet_Mcm - 000D63_SkyrimNet.esp.json` (added \`TelepathyListenInSpell\` property)
- `Source/Scripts/skynet_McmScript.psc` (new property + Add/Remove buttons + tooltip + section)

## Test plan

- [ ] In MCM, both Add buttons grant the corresponding spell; Remove buttons revoke.
- [ ] Cast \`Telepathy: Listen In\` with full magicka — magicka drops by ~140; with Adept Illusion perk dropped to ~70-80.
- [ ] Cast is instant and inaudible.
- [ ] Eavesdropping turns ON immediately, OFF after 60s (notification fires both times).
- [ ] Cast Listen In while debug toggle is ON → after 60s, eavesdropping is forced OFF (matches tooltip warning).
- [ ] Spell appears in spell book under Illusion school with description text rendering correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)