### PR TITLE
add default voice effects, papyrus api

### DIFF
--- a/SKSE/Plugins/SkyrimNet/original_voice_effects/dragon_priest.yaml
+++ b/SKSE/Plugins/SkyrimNet/original_voice_effects/dragon_priest.yaml
@@ -1,0 +1,21 @@
+id: dragon_priest
+name: Dragon Priest
+sample: null
+stages:
+  - type: formant_shift
+    params:
+      semitones: -1.0
+  - type: pitch_shift
+    params:
+      semitones: -4.0
+  - type: eq
+    params:
+      mode: low
+      freq_hz: 5000.0
+      q: 0.8
+      gain_db: -3.0
+  - type: reverb
+    params:
+      room_size: 0.85
+      decay: 0.8
+      wet: 0.5

--- a/SKSE/Plugins/SkyrimNet/original_voice_effects/draugr.yaml
+++ b/SKSE/Plugins/SkyrimNet/original_voice_effects/draugr.yaml
@@ -1,0 +1,23 @@
+id: draugr
+name: Draugr
+sample: null
+stages:
+  - type: formant_shift
+    params:
+      semitones: -2.0
+  - type: pitch_shift
+    params:
+      semitones: -6.0
+  - type: bitcrush
+    params:
+      bits: 10
+      rate_div: 2
+  - type: distortion
+    params:
+      drive: 0.55
+      mix: 0.7
+  - type: reverb
+    params:
+      room_size: 0.5
+      decay: 0.6
+      wet: 0.3

--- a/SKSE/Plugins/SkyrimNet/original_voice_effects/dremora.yaml
+++ b/SKSE/Plugins/SkyrimNet/original_voice_effects/dremora.yaml
@@ -1,0 +1,20 @@
+id: dremora
+name: Dremora
+sample: null
+stages:
+  - type: pitch_shift
+    params:
+      semitones: -3.0
+  - type: ringmod
+    params:
+      freq_hz: 80.0
+      mix: 0.18
+  - type: distortion
+    params:
+      drive: 0.35
+      mix: 0.5
+  - type: reverb
+    params:
+      room_size: 0.4
+      decay: 0.5
+      wet: 0.25

--- a/SKSE/Plugins/SkyrimNet/original_voice_effects/ghost.yaml
+++ b/SKSE/Plugins/SkyrimNet/original_voice_effects/ghost.yaml
@@ -1,0 +1,21 @@
+id: ghost
+name: Ghost
+sample: null
+stages:
+  - type: pitch_shift
+    params:
+      semitones: -1.0
+  - type: chorus
+    params:
+      rate_hz: 0.8
+      depth_ms: 5.0
+      voices: 3
+  - type: whisper
+    params:
+      noise_db: -28.0
+      mix: 0.25
+  - type: reverb
+    params:
+      room_size: 0.9
+      decay: 0.85
+      wet: 0.55

--- a/SKSE/Plugins/SkyrimNet/original_voice_effects/vampire_lord.yaml
+++ b/SKSE/Plugins/SkyrimNet/original_voice_effects/vampire_lord.yaml
@@ -1,0 +1,24 @@
+id: vampire_lord
+name: Vampire Lord
+sample: null
+stages:
+  - type: formant_shift
+    params:
+      semitones: -2.0
+  - type: pitch_shift
+    params:
+      semitones: -4.0
+  - type: eq
+    params:
+      mode: low
+      freq_hz: 4000.0
+      q: 0.7
+      gain_db: 2.0
+  - type: reverb
+    params:
+      room_size: 0.6
+      decay: 0.7
+      wet: 0.35
+  - type: gain
+    params:
+      gain_db: 2.0

--- a/SKSE/Plugins/SkyrimNet/original_voice_effects/werewolf.yaml
+++ b/SKSE/Plugins/SkyrimNet/original_voice_effects/werewolf.yaml
@@ -1,0 +1,19 @@
+id: werewolf
+name: Werewolf
+sample: null
+stages:
+  - type: formant_shift
+    params:
+      semitones: -3.0
+  - type: pitch_shift
+    params:
+      semitones: -5.0
+  - type: distortion
+    params:
+      drive: 0.4
+      mix: 0.6
+  - type: reverb
+    params:
+      room_size: 0.3
+      decay: 0.4
+      wet: 0.25

--- a/Source/Scripts/SkyrimNetApi.psc
+++ b/Source/Scripts/SkyrimNetApi.psc
@@ -808,3 +808,26 @@ int function TriggerSilentNarration() Global Native
 ;       true, 0.8, "Companions Lore")
 int function AddWorldKnowledge(String content, String conditionExpr, bool alwaysInject, float importance, String displayName) Global Native
 
+; -----------------------------------------------------------------------------
+; --- Voice Effect Management ---
+; -----------------------------------------------------------------------------
+
+; Set the active voice effect for an actor.
+; - akActor: Actor to update
+; - asEffectId: Effect recipe id (e.g. "werewolf"). Pass "" to clear.
+; Returns 0 on success, 1 on failure (unknown actor or effect id).
+int function SetVoiceEffect(Actor akActor, String asEffectId) Global Native
+
+; Clear the active voice effect for an actor (equivalent to SetVoiceEffect with "").
+; Returns 0 on success, 1 on failure.
+int function ClearVoiceEffect(Actor akActor) Global Native
+
+; Get the current voice effect id assigned to an actor.
+; Returns "" if none.
+String function GetVoiceEffect(Actor akActor) Global Native
+
+; UUID variants (for virtual entities or when you already have the UUID).
+int function SetVoiceEffectByUUID(String asEntityUUID, String asEffectId) Global Native
+int function ClearVoiceEffectByUUID(String asEntityUUID) Global Native
+String function GetVoiceEffectByUUID(String asEntityUUID) Global Native
+


### PR DESCRIPTION
Adds Papyrus API and sample definitions for the new Voice Effects feature.
Note that the sample definitions are very much placeholder - they are not terribly accurate to their names, e.g. Werewolf does not sound much like a werewolf.