### PR TITLE
Add thoughts effect recipes for use with player thoughts, narrator, telepathy

### DIFF
--- a/SKSE/Plugins/SkyrimNet/original_voice_effects/narrator_reverb.yaml
+++ b/SKSE/Plugins/SkyrimNet/original_voice_effects/narrator_reverb.yaml
@@ -1,0 +1,9 @@
+id: narrator_effect
+name: Narrator Effect
+sample: null
+stages:
+  - type: echo
+    params:
+      delay_ms: 200
+      feedback: 0.05
+      wet: 0.35

--- a/SKSE/Plugins/SkyrimNet/original_voice_effects/player_thought_overlay.yaml
+++ b/SKSE/Plugins/SkyrimNet/original_voice_effects/player_thought_overlay.yaml
@@ -1,0 +1,9 @@
+id: player_thought_effect
+name: Player Thought Effect
+sample: null
+stages:
+  - type: echo
+    params:
+      delay_ms: 200
+      feedback: 0.05
+      wet: 0.35


### PR DESCRIPTION
Two new effect recipes, in order to migrate the existing Player Thoughts, Narrator, and Telepathy echo effects to the new Voice Effects system.
The old approach reused the player thoughts effect for telepathy, so I've done the same here rather than making a separate yaml file.

These may not be exactly equivalent to the previous effect, but it should be pretty close. The `wet` value in particular can be adjusted if it doesn't sound as desired.