### PR TITLE
prompts(target_selectors): tag dialogue speaker selector candidates from SkyrimNet config

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/target_selectors/dialogue_speaker_selector.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/target_selectors/dialogue_speaker_selector.prompt
@@ -1,9 +1,13 @@
 [ system ]
+{% set zerochance = papyrus_util("GetIntValue", 0, "SeverActions_ZeroChance", 50) %}
+{% set tagCompanion = papyrus_util("GetIntValue", 0, "SeverActions_TagCompanion", 1) %}
+{% set tagEngaged = papyrus_util("GetIntValue", 0, "SeverActions_TagEngaged", 1) %}
+{% set tagInScene = papyrus_util("GetIntValue", 0, "SeverActions_TagInScene", 1) %}
 ## Task
-Select which NPC should speak next, if anyone. Output only: `0` (silence) or `[speaker]>[target]`
+Select which NPC should speak next, if anyone. Output only: {% if random < zerochance %}`0` (silence) or {% endif %}`[speaker]>[target]`
 
 ## Output Format
-- `0` = No one speaks
+{% if random < zerochance %}- `0` = No one speaks{% endif %}
 - `Lydia>player` = Lydia speaks to player
 - `Ulfric Stormcloak>Galmar Stone-Fist` = Ulfric speaks to Galmar
 
@@ -13,16 +17,17 @@ Evaluate candidates using these factors (highest priority first):
 1. **Direct involvement**: Was this NPC explicitly addressed, referenced by name, or directly involved in what just happened?
 2. **Unresolved exchange**: Someone was asked a direct question or given a request that hasn't been answered yet. This is the ONLY conversational momentum that demands continuation — not vague topical interest.
 3. **Authority/duty**: Does their role (guard, merchant, innkeeper, jarl) demand a response in this situation?
-4. **Personal stakes**: Are they emotionally affected (friend, family, ally, rival involved)?
-5. **Witnessed event**: Did they clearly witness something noteworthy that they'd realistically react to?
-6. **Interjection profile**: Does their Interjection guidance indicate they'd speak here?
+{% if tagCompanion %}4. **Companion awareness**: Is this NPC a follower or companion? Companions are traveling with the player — they react to combat, close calls, discoveries, new locations, strange situations, and what's being discussed. They have opinions, personalities, and things to say. A companion speaking up feels natural; a party of silent followers does not.
+{% endif %}5. **Personal stakes**: Are they emotionally affected (friend, family, ally, rival involved)?
+6. **Witnessed event**: Did they clearly witness something noteworthy that they'd realistically react to?
+7. **Interjection profile**: Does their Interjection guidance indicate they'd speak here?
 
 ## When to Choose Silence (0)
-Silence is preferred when uncertain. Not every line needs a reply — conversations should end naturally.
+Silence is preferred when uncertain. Not every line needs a reply — conversations should end naturally.{% if tagCompanion %} But don't default to silence when a companion would realistically have something to say. Traveling companions talk; err toward letting them speak when there's even a mild reason to.{% endif %}
 
 Choose silence when:
-{% if lastDialogueTarget.name %}- **Direct question to the player** — {{ lastSpeaker.name }} just spoke to {% if lastDialogueTarget.UUID == player.UUID %}the player{% else %}{{ lastDialogueTarget.name }}{% endif %}. {% if lastDialogueTarget.UUID == player.UUID %}If it was a **direct question or request**, choose silence — the player should answer.{% endif %}
-{% else %}- **Direct question to the player** — If an NPC asked the player a direct question or made a direct request, choose silence so the player can respond.
+{% if lastDialogueTarget.name %}- **Direct question to the player** — {{ lastSpeaker.name }} just spoke to {% if lastDialogueTarget.UUID == player.UUID %}the player{% else %}{{ lastDialogueTarget.name }}{% endif %}. {% if lastDialogueTarget.UUID == player.UUID %}If it was a **direct question or request**, choose silence — the player should answer. However, if it was just a statement, observation, or comment, another companion may react (speaking to each other or to {{ lastSpeaker.name }}, NOT to the player).{% endif %}
+{% else %}- **Direct question to the player** — If an NPC asked the player a direct question or made a direct request, choose silence so the player can respond. But if the last line was just a statement or observation directed at the player, other companions are free to react.
 {% endif %}- The last exchange was a natural conclusion — farewell, transaction complete, question answered, agreement reached
 - The last response was a closing statement — acknowledgment, thanks, agreement, or farewell. These do NOT need replies.
 - The same two NPCs have been going back and forth for several turns — the topic is likely exhausted
@@ -33,13 +38,17 @@ Choose silence when:
 Do NOT choose silence when:
 - Someone was asked a direct question that hasn't been answered
 - Something dramatic, dangerous, funny, or unexpected just happened
-- Two NPCs are mid-conversation — let it reach a natural conclusion before going silent
+{% if tagCompanion %}- A companion witnessed something involving the player — even a short reaction counts
+- The player just made a decision, statement, or action that a companion would have thoughts on
+- The party just arrived somewhere new or interesting
+- A companion's personality or background makes them likely to comment on the current situation
+{% endif %}- Two NPCs are mid-conversation — let it reach a natural conclusion before going silent
 
 **Restrictions:**
-- Never select an NPC just because they're listed — proximity alone is not a reason for bystanders to speak
+- Never select a non-companion NPC just because they're listed — proximity alone is not a reason for bystanders to speak
 - Honor each NPC's Interjection guidance strictly
 - Do NOT select {{ lastSpeaker.name }} as speaker (they just spoke — but they CAN be selected as target)
-{% if lastDialogueTarget.name %}- {{ lastSpeaker.name }} was addressing {% if lastDialogueTarget.UUID == player.UUID %}the player{% else %}{{ lastDialogueTarget.name }}{% endif %}.{% if lastDialogueTarget.UUID != player.UUID %} {{ lastDialogueTarget.name }} is the natural next speaker if the exchange warrants a reply.{% endif %}
+{% if lastDialogueTarget.name %}- {{ lastSpeaker.name }} was addressing {% if lastDialogueTarget.UUID == player.UUID %}the player{% else %}{{ lastDialogueTarget.name }}{% endif %}. {% if lastDialogueTarget.UUID == player.UUID %}If it was a direct question, prefer silence. If it was a statement or comment, a companion may speak — but they should address {{ lastSpeaker.name }} or another companion, not the player.{% else %}{{ lastDialogueTarget.name }} is the natural next speaker if the exchange warrants a reply.{% endif %}
 {% endif %}- **No meta-commentary about silence** — Never select an NPC to comment on the player not talking, to urge the player to speak, or to narrate the waiting. NPCs do not have awareness that "the player is taking too long to respond" — they simply wait.
 - Regular NPCs cannot hear Virtual NPCs. Do not select an NPC to respond directly to a Virtual NPC.
 - Virtual NPCs may be selected as speaker but may NOT be selected as a target unless the speaker is also a Virtual NPC.
@@ -69,24 +78,32 @@ Do NOT choose silence when:
    - {{ render_character_profile("short_inline", candidate.UUID) }}
    - **Interjection**: {{ render_character_profile("interject_inline", candidate.UUID) }}
 {% else %}
-{{ candidate.id }}. **{{ cinfo.name }}** ({{ cinfo.gender }} {{ cinfo.race }}, {{ units_to_meters(candidate.distance) }}m)
+{{ candidate.id }}. **{{ cinfo.name }}** ({{ cinfo.gender }} {{ cinfo.race }}, {{ units_to_meters(candidate.distance) }}m){% if tagCompanion and is_follower(candidate.UUID) %} **[COMPANION]**{% endif %}{% if tagEngaged and is_in_faction(candidate.UUID, "SeverActions_ActivelyFollowing") %} **[ENGAGED]**{% endif %}{% if tagInScene and (is_in_faction(candidate.UUID, "SexLabAnimatingFaction") or is_in_faction(candidate.UUID, "OStimExcitementFaction")) %} **[IN SCENE]**{% endif %}
    - {{ render_character_profile("short_inline", candidate.UUID) }}
    - **Interjection**: {{ render_character_profile("interject_inline", candidate.UUID) }}
 {% endif %}
 {% endif %}
 {% endfor %}
 
+{% if tagCompanion or tagEngaged or tagInScene %}
+**Tag meanings:**
+{% if tagCompanion %}- `[COMPANION]` — Player's active follower. More invested in the player's affairs and naturally reacts to things around the player.
+{% endif %}{% if tagEngaged %}- `[ENGAGED]` — This NPC has heightened conversational engagement and a lower threshold to speak. They are more likely to initiate or join conversations. If multiple ENGAGED NPCs are present, don't let them dominate — mix in other speakers or natural pauses so the player and non-ENGAGED NPCs have room to participate.
+{% endif %}{% if tagInScene %}- `[IN SCENE]` — This NPC is currently in an intimate/sexual scene. **Strongly deprioritize** — they are physically occupied and should almost never be selected as speaker. Only select them if directly addressed by name or asked a direct question. Their companion/engaged status is overridden while in a scene.
+{% endif %}{% endif %}
+
 **Targeting rules:**
 - Consider who was just speaking to whom.{% if existsIn(lastSpeaker, "name") and existsIn(lastDialogueTarget, "name") %} {{ lastSpeaker.name }} was just speaking to {{ lastDialogueTarget.name }} — if {{ lastDialogueTarget.name }} is a candidate, they should typically respond back to {{ lastSpeaker.name }}, not redirect to the player.{% endif %}
 - Only use `player` as target when the NPC is genuinely addressing the player.
 - NPC-to-NPC exchanges should wind down. After 2-3 back-and-forths between the same two NPCs, the topic is usually resolved — the next turn can pivot back to the player (target = `player`) or end in silence.
 - A chosen speaker CAN pivot their target back to `player` even if the immediately prior line was NPC-to-NPC — if the speaker's reason to speak is genuinely directed at the player (reacting to something the player did, answering the player's earlier question, sharing a decision with the player, pulling the player's attention to something), target = `player`. The prior NPC-to-NPC line does not lock in future targeting.
+- When in doubt between continuing NPC-to-NPC vs pivoting to player: if the player was the scene's original initiator and the NPC-to-NPC exchange was a brief side-comment, pivot back to player.
 - **Always specify a target** — every output must be exactly `0` or `[speaker]>[target]`. Never output `[speaker]>` with an empty target. Never leave the target ambiguous or unnamed. If unsure, prefer `player` over an NPC name you're not confident about.
 
 ### Examples
 - CORRECT: `Aela the Huntress>Lydia`
-- CORRECT: `0`
-- INCORRECT: `Aela the Huntress [Female Nord]>Lydia` (do not add gender and race)
+{% if random < zerochance %}- CORRECT: `0`
+{% endif %}- INCORRECT: `Aela the Huntress [Female Nord]>Lydia` (do not add gender and race)
 - INCORRECT: `Aela the Huntress to Lydia` (use ">" not "to")
 - INCORRECT: `**Aela the Huntress**>**Lydia**` (no asterisks)
 - INCORRECT: `Aela>Lydia` (use exact full name, not shortened)
@@ -94,5 +111,5 @@ Do NOT choose silence when:
 - INCORRECT: `Aela the Huntress>Lydia (because of context)` (no commentary)
 
 IMPORTANT: Do NOT select {{ lastSpeaker.name }} as speaker!
-Output format: `0` or `[Name]>[target]`
+Output format:{% if random < zerochance %} `0` or {% endif %} `[Name]>[target]`
 [ end user ]

--- a/SKSE/Plugins/SkyrimNet/prompts/target_selectors/dialogue_speaker_selector.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/target_selectors/dialogue_speaker_selector.prompt
@@ -1,8 +1,9 @@
 [ system ]
-{% set zerochance = papyrus_util("GetIntValue", 0, "SeverActions_ZeroChance", 50) %}
-{% set tagCompanion = papyrus_util("GetIntValue", 0, "SeverActions_TagCompanion", 1) %}
-{% set tagEngaged = papyrus_util("GetIntValue", 0, "SeverActions_TagEngaged", 1) %}
-{% set tagInScene = papyrus_util("GetIntValue", 0, "SeverActions_TagInScene", 1) %}
+{% set ss = get_speaker_selector_settings() %}
+{% set zerochance = ss.silenceChancePercent %}
+{% set tagCompanion = ss.tagCompanion %}
+{% set tagEngaged = ss.tagEngaged %}
+{% set tagInScene = ss.tagInScene %}
 ## Task
 Select which NPC should speak next, if anyone. Output only: {% if random < zerochance %}`0` (silence) or {% endif %}`[speaker]>[target]`
 
@@ -78,7 +79,7 @@ Do NOT choose silence when:
    - {{ render_character_profile("short_inline", candidate.UUID) }}
    - **Interjection**: {{ render_character_profile("interject_inline", candidate.UUID) }}
 {% else %}
-{{ candidate.id }}. **{{ cinfo.name }}** ({{ cinfo.gender }} {{ cinfo.race }}, {{ units_to_meters(candidate.distance) }}m){% if tagCompanion and is_follower(candidate.UUID) %} **[COMPANION]**{% endif %}{% if tagEngaged and is_in_faction(candidate.UUID, "SeverActions_ActivelyFollowing") %} **[ENGAGED]**{% endif %}{% if tagInScene and (is_in_faction(candidate.UUID, "SexLabAnimatingFaction") or is_in_faction(candidate.UUID, "OStimExcitementFaction")) %} **[IN SCENE]**{% endif %}
+{{ candidate.id }}. **{{ cinfo.name }}** ({{ cinfo.gender }} {{ cinfo.race }}, {{ units_to_meters(candidate.distance) }}m){% if tagCompanion and is_follower(candidate.UUID) %} **[COMPANION]**{% endif %}{% if tagEngaged and is_in_package(candidate.UUID, "SkyrimNet_PlayerFollowPackage") %} **[ENGAGED]**{% endif %}{% if tagInScene and (is_in_faction(candidate.UUID, "SexLabAnimatingFaction") or is_in_faction(candidate.UUID, "OStimExcitementFaction")) %} **[IN SCENE]**{% endif %}
    - {{ render_character_profile("short_inline", candidate.UUID) }}
    - **Interjection**: {{ render_character_profile("interject_inline", candidate.UUID) }}
 {% endif %}


### PR DESCRIPTION
## Summary

Adds three optional `[COMPANION]` / `[ENGAGED]` / `[IN SCENE]` annotations to candidate NPCs in `dialogue_speaker_selector.prompt`, plus a configurable silence-option rate, all driven by SkyrimNet's GameConfig — surfaced in the in-game dashboard under **Settings → Conversations → Speaker Selector**.

| Tag | Condition |
|---|---|
| `[COMPANION]` | `is_follower(uuid)` (vanilla CurrentFollowerFaction) |
| `[ENGAGED]` | `is_in_package(uuid, "SkyrimNet_PlayerFollowPackage")` — NPC is running SkyrimNet's follow package |
| `[IN SCENE]` | `is_in_faction(uuid, "SexLabAnimatingFaction" or "OStimExcitementFaction")` |

The silence option is gated on `random < ss.silenceChancePercent`, where the percentage comes from `dialogue.speakerSelector.silenceChancePercent` in GameConfig.

A single `get_speaker_selector_settings()` decorator call reads all four values:

```jinja
{% set ss = get_speaker_selector_settings() %}
{% set zerochance = ss.silenceChancePercent %}
{% set tagCompanion = ss.tagCompanion %}
{% set tagEngaged = ss.tagEngaged %}
{% set tagInScene = ss.tagInScene %}
```

## Why these belong upstream

- **Companion awareness** — anyone running SkyrimNet with a follower benefits from companions speaking up more naturally. Today's prompt makes no distinction between a follower and a random townsperson.
- **Scene awareness** — prevents SexLab/OStim participants from being LLM-selected as speakers mid-animation.
- **Silence rate** — global tuning knob; some prefer a chattier world, some terser exchanges.

## Configuration

All four behaviors read from SkyrimNet's GameConfig (no external mod dependencies). Defaults are sensible-on so the prompt has useful baseline behavior out of the box; defaults can be tuned per-modlist from the dashboard:

| GameConfig path | Default | Effect |
|---|---|---|
| `dialogue.speakerSelector.silenceChancePercent` | 50 | Probability the silence option is offered to the LLM |
| `dialogue.speakerSelector.tagCompanion` | true | Renders `[COMPANION]` tag + companion-aware prose |
| `dialogue.speakerSelector.tagEngaged` | true | Renders `[ENGAGED]` tag |
| `dialogue.speakerSelector.tagInScene` | true | Renders `[IN SCENE]` tag |

## Graceful degradation

- Without SexLab/OStim installed → `is_in_faction("SexLabAnimatingFaction" / "OStimExcitementFaction")` returns false → `[IN SCENE]` silently never appears.
- Without an active SkyrimNet follow → `is_in_package` returns false → `[ENGAGED]` silently never appears.

## Requires

SkyrimNet build with [MinLL/SkyrimNet#807](https://github.com/MinLL/SkyrimNet/pull/807) merged (adds `get_speaker_selector_settings()`, `is_in_package`, and the GameConfig keys).

## Test plan

- [ ] Render with a follower nearby → `[COMPANION]` appears next to them in the candidate list
- [ ] Render with an NPC running `SkyrimNet_PlayerFollowPackage` → `[ENGAGED]` appears
- [ ] Render with a SexLab/OStim participant → `[IN SCENE]` appears
- [ ] Toggle each `dialogue.speakerSelector.tag*` off in dashboard → corresponding tag and its tag-meanings entry disappear
- [ ] `silenceChancePercent = 0` → silence option never offered (no `0` in task / output / examples)
- [ ] `silenceChancePercent = 100` → silence option always offered
- [ ] Validate prompt with `mcp__skyrimnet__validate_prompt`

## Related

Pairs with #386 (`player_dialogue_target_selector` tags). Both PRs are independent — either can land without the other, but together they give a consistent tagging experience across the two target-selector prompts. A toggle in the dashboard affects both prompts in lockstep, which is what a user would expect.