### PR TITLE
feat: handle unconscious state & fix empty furniture descriptions

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/components/character_bio_dialogue_target.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/character_bio_dialogue_target.prompt
@@ -10,6 +10,9 @@
 {% endif %}
 - Gender: {{ decnpc(npc.UUID).gender }}
 - Race: {{ decnpc(npc.UUID).race }}
+{% if is_unconscious(npc.UUID) %}
+- Currently knocked-out: {{ decnpc(npc.UUID).name }} is unconscious. **They are unable to speak or respond in anyway.**
+{% endif %}
 ## Summary
 {% block summary %}{% endblock %}
 ## Appearance

--- a/SKSE/Plugins/SkyrimNet/prompts/components/context/component_npc_state_summary.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/context/component_npc_state_summary.prompt
@@ -2,6 +2,9 @@
 {% set nearby_npcs = get_nearby_npc_list(player.UUID) %}
 
 {% for npc in nearby_npcs %}
+    {% if is_unconscious(npc.UUID) %}
+    - {{ npc.name }} is unconscious & unresponsive
+    {% endif %}
     {% if npc.isFollowing %}
         - {{ npc.name }} is following {{ player.name }}
     {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/components/context/component_npc_state_summary.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/context/component_npc_state_summary.prompt
@@ -2,55 +2,58 @@
 {% set nearby_npcs = get_nearby_npc_list(player.UUID) %}
 
 {% for npc in nearby_npcs %}
-    {% if is_unconscious(npc.UUID) %}
-    - {{ npc.name }} is unconscious & unresponsive
-    {% endif %}
     {% if npc.isFollowing %}
         - {{ npc.name }} is following {{ player.name }}
     {% endif %}
-    {% if npc.furniture != "None" %}
+    {% if is_unconscious(npc.UUID) %}
+    - {{ npc.name }} is unconscious & unresponsive
+    {% elif npc.furniture != "None" %}
         {# Convert furniture name to lowercase for matching #}
         {% set furniture_lower = lower(npc.furniture) %}
-
+        {% if length(npc.furniture) > 0 %}
+            {% set furniture_name = "a " + npc.furniture %}
+        {% else %}
+            {% set furniture_name = "something" %}
+        {% endif %}
         {# Determine appropriate action based on furniture type #}
         {% if "bed" in furniture_lower or "bedroll" in furniture_lower or "cot" in furniture_lower or "hay pile" in furniture_lower or "fur" in furniture_lower or "animal hide" in furniture_lower or "pelts" in furniture_lower or "sleeping bag" in furniture_lower %}
-            - {{ npc.name }} is lying down in a {{ npc.furniture }}
+            - {{ npc.name }} is lying down in {{ furniture_name }}
         {% else if  "table" in furniture_lower or "desk" in furniture_lower %}
-            - {{ npc.name }} is sitting at a {{ npc.furniture }}
+            - {{ npc.name }} is sitting at {{ furniture_name }}
         {% else if  "alchemy" in furniture_lower or "mortar" in furniture_lower or "pestle" in furniture_lower %}
-            - {{ npc.name }} is using a {{ npc.furniture }} to mix potions
+            - {{ npc.name }} is using {{ furniture_name }} to mix potions
         {% else if  "enchant" in furniture_lower or "arcane" in furniture_lower or "soul gem" in furniture_lower %}
-            - {{ npc.name }} is using a {{ npc.furniture }} to enchant items
+            - {{ npc.name }} is using {{ furniture_name }} to enchant items
         {% else if  "forge" in furniture_lower or "anvil" in furniture_lower or "grindstone" in furniture_lower or "tanning rack" in furniture_lower or "smelter" in furniture_lower %}
-            - {{ npc.name }} is working at a {{ npc.furniture }} sharpening a sword
+            - {{ npc.name }} is working at {{ furniture_name }} sharpening a sword
         {% else if  "cooking pot" in furniture_lower or "spit" in furniture_lower or "oven" in furniture_lower or "cauldron" in furniture_lower or "kettle" in furniture_lower %}
-            - {{ npc.name }} is preparing food at a {{ npc.furniture }}
+            - {{ npc.name }} is preparing food at {{ furniture_name }}
         {% else if  "shrine" in furniture_lower or "altar" in furniture_lower or "standing stone" in furniture_lower or "wayshrine" in furniture_lower or "statue" in furniture_lower %}
-            - {{ npc.name }} is praying at a {{ npc.furniture }}
+            - {{ npc.name }} is praying at {{ furniture_name }}
         {% else if  "throne" in furniture_lower or "jarl seat" in furniture_lower %}
-            - {{ npc.name }} is sitting upon a {{ npc.furniture }}
+            - {{ npc.name }} is sitting upon {{ furniture_name }}
         {% else if  "chest" in furniture_lower or "box" in furniture_lower or "container" in furniture_lower or "drawer" in furniture_lower or "wardrobe" in furniture_lower or "cabinet" in furniture_lower or "barrel" in furniture_lower or "urn" in furniture_lower or "sack" in furniture_lower %}
-            - {{ npc.name }} is searching through a {{ npc.furniture }}
+            - {{ npc.name }} is searching through {{ furniture_name }}
         {% else if  "book" in furniture_lower or "journal" in furniture_lower or "note" in furniture_lower or "letter" in furniture_lower or "tome" in furniture_lower or "scroll" in furniture_lower %}
-            - {{ npc.name }} is reading a {{ npc.furniture }}
+            - {{ npc.name }} is reading {{ furniture_name }}
         {% else if  "bath" in furniture_lower or "pool" in furniture_lower or "hot spring" in furniture_lower or "basin" in furniture_lower or "fountain" in furniture_lower %}
-            - {{ npc.name }} is bathing in a {{ npc.furniture }}
+            - {{ npc.name }} is bathing in {{ furniture_name }}
         {% else if  "well" in furniture_lower or "pump" in furniture_lower or "stream" in furniture_lower or "river" in furniture_lower or "lake" in furniture_lower or "pond" in furniture_lower or "spring" in furniture_lower %}
-            - {{ npc.name }} is drawing water from a {{ npc.furniture }}
+            - {{ npc.name }} is drawing water from {{ furniture_name }}
         {% else if  "lute" in furniture_lower or "drum" in furniture_lower or "flute" in furniture_lower or "horn" in furniture_lower %}
-            - {{ npc.name }} is playing a {{ npc.furniture }}
+            - {{ npc.name }} is playing {{ furniture_name }}
         {% else if  "training dummy" in furniture_lower or "archery target" in furniture_lower or "practice target" in furniture_lower %}
-            - {{ npc.name }} is practicing on a {{ npc.furniture }}
+            - {{ npc.name }} is practicing on {{ furniture_name }}
         {% else if  "workbench" in furniture_lower %}
-            - {{ npc.name }} is working at a {{ npc.furniture }} crafting items
+            - {{ npc.name }} is working at {{ furniture_name }} crafting items
         {% else if  "chair" in furniture_lower or "stool" in furniture_lower or "bench" in furniture_lower or "seat" in furniture_lower %}
-            - {{ npc.name }} is sitting on a {{ npc.furniture }}
+            - {{ npc.name }} is sitting on {{ furniture_name }}
         {% else if "chopping block" in furniture_lower %}
             - {{ npc.name }} is chopping wood at the {{ npc.furniture }}
         {% else if "counter" in furniture_lower %}
-            - {{ npc.name }} is leaning against a {{ npc.furniture }}
+            - {{ npc.name }} is leaning against {{ furniture_name }}
         {% else %}
-            - {{ npc.name }} is interacting with a {{ npc.furniture }}
+            - {{ npc.name }} is interacting with {{ furniture_name }}
         {% endif %}
     {% endif %}
 {% endfor %}

--- a/SKSE/Plugins/SkyrimNet/prompts/components/context/scene_context.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/context/scene_context.prompt
@@ -15,6 +15,8 @@
         {% for npc in nearby_npcs %}
             {% if decnpc(npc.UUID).isDead %}
                 {{ npc.id }}. [DEAD] The dead corpse of {{ decnpc(npc.UUID).name }}: {{ render_character_profile("short_inline", npc.UUID) }} ({{ decnpc(npc.UUID).gender }} {{ decnpc(npc.UUID).race }}, {{ units_to_meters(npc.distance) }} meters away)
+            {% else if is_unconscious(npc.UUID) %}
+                {{ npc.id }}. [UNCONSCIOUS] The unconscious, unresponsive form of {{ decnpc(npc.UUID).name }}: {{ render_character_profile("short_inline", npc.UUID) }} ({{ decnpc(npc.UUID).gender }} {{ decnpc(npc.UUID).race }}, {{ units_to_meters(npc.distance) }} meters away)
             {% else %}
                 {{ npc.id }}. {% if is_summoned(npc.UUID) %}{% if is_hostile_to_actor(npc.UUID, player.UUID) %}[Summoned creature hostile to {{ decnpc(player.UUID).name }}] {% else %}[Summoned creature serving {{ decnpc(player.UUID).name }}] {% endif %}{% else if is_reanimated(npc.UUID) %}{% if is_hostile_to_actor(npc.UUID, player.UUID) %}[Reanimated undead hostile to {{ decnpc(player.UUID).name }}] {% else %}[Reanimated undead thrall serving {{ decnpc(player.UUID).name }}] {% endif %}{% endif %}{{ decnpc(npc.UUID).name }}{% if decnpc(npc.UUID).isVirtualPrivate %} (Virtual NPC){% endif %}: {{ render_character_profile("short_inline", npc.UUID) }}{% if not decnpc(npc.UUID).isVirtual %} ({{ decnpc(npc.UUID).gender }} {{ decnpc(npc.UUID).race }}, {{ units_to_meters(npc.distance) }} meters away){% endif %}
             {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/omnisight/describe_scene.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/omnisight/describe_scene.prompt
@@ -12,7 +12,7 @@
     ## Visible People (authoritative list; everyone below is on-camera):
     {% for npc in visibleNPCs %}
         {% set pos = get_actor_position_relative_to_camera(npc.UUID) %}
-        - {{npc.name}} ({{decnpc(npc.UUID).race}}, {{decnpc(npc.UUID).gender}}) — {{pos.meters}}m, {{pos.cardinalDirection}} {% if is_in_combat(npc.UUID) %}[COMBAT] {% endif %}{% if has_weapon_drawn(npc.UUID) %}[Armed] {% endif %}{% if is_swimming(npc.UUID) %}[Swimming]{% else if is_sprinting(npc.UUID) %}[Running]{% else if is_sneaking(npc.UUID) %}[Sneaking]{% endif %}
+        - {{npc.name}} ({{decnpc(npc.UUID).race}}, {{decnpc(npc.UUID).gender}}) — {{pos.meters}}m, {{pos.cardinalDirection}} {% if is_unconscious(npc.UUID) %}[UNCONSCIOUS] {% else %}{% if is_in_combat(npc.UUID) %}[COMBAT] {% endif %}{% if has_weapon_drawn(npc.UUID) %}[Armed] {% endif %}{% if is_swimming(npc.UUID) %}[Swimming]{% else if is_sprinting(npc.UUID) %}[Running]{% else if is_sneaking(npc.UUID) %}[Sneaking]{% endif %}{% endif %}
     {% endfor %}
     {% else %}
     ## Visible People: (none detected)

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0050_physical_activity.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0050_physical_activity.prompt
@@ -2,20 +2,21 @@
     ## Physical Activity
     {% if is_unconscious(actorUUID) %}
         - {{ decnpc(actorUUID).name }} is currently unconscious and unable to move or act.
-    {% endif %}
-    {% if is_sneaking(actorUUID) %}
-        - {{ decnpc(actorUUID).name }} is currently trying to move silently, and avoid being seen or heard.
-    {% endif %}
-    {% if is_walking(actorUUID) %}
-        - {{ decnpc(actorUUID).name }} is currently walking at a steady pace.
-    {% endif %}
-    {% if is_sprinting(actorUUID) %}
-        - {{ decnpc(actorUUID).name }} is currently sprinting at full speed.
-    {% endif %}
-    {% if is_swimming(actorUUID) %}
-        - {{ decnpc(actorUUID).name }} is currently swimming.
-    {% endif %}
-    {% if is_knocked_down(actorUUID) %}
-        - {{ decnpc(actorUUID).name }} is currently badly wounded, and is kneeling on the ground.
+    {% else %}
+        {% if is_sneaking(actorUUID) %}
+            - {{ decnpc(actorUUID).name }} is currently trying to move silently, and avoid being seen or heard.
+        {% endif %}
+        {% if is_walking(actorUUID) %}
+                - {{ decnpc(actorUUID).name }} is currently able to move normally.
+        {% endif %}
+        {% if is_sprinting(actorUUID) %}
+            - {{ decnpc(actorUUID).name }} is currently sprinting at full speed.
+        {% endif %}
+        {% if is_swimming(actorUUID) %}
+            - {{ decnpc(actorUUID).name }} is currently swimming.
+        {% endif %}
+        {% if is_knocked_down(actorUUID) %}
+            - {{ decnpc(actorUUID).name }} is currently badly wounded, and is kneeling on the ground.
+        {% endif %}
     {% endif %}
 {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0200_combat_status.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0200_combat_status.prompt
@@ -22,7 +22,8 @@
 {% else %}- Full magical power
 {% endif %}
 {% endif %}
-{% if staminaRatio < 0.25 %}- Gasping, exhausted, can barely swing
+{% if is_unconscious(npc.UUID) %}- Unconscious and unable to act
+{% elif staminaRatio < 0.25 %}- Gasping, exhausted, can barely swing
 {% elif staminaRatio < 0.5 %}- Winded and slowing down
 {% elif staminaRatio < 0.75 %}- Breathing hard but capable
 {% else %}- Energy to spare

--- a/SKSE/Plugins/SkyrimNet/prompts/target_selectors/player_dialogue_target_selector.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/target_selectors/player_dialogue_target_selector.prompt
@@ -12,6 +12,9 @@ Determine which NPC the player is addressing and who should respond. Analyze the
 {% if crosshairTarget and crosshairTarget.UUID and crosshairTarget.UUID != 0 %}
 {{ "## Player's Crosshair Target" }}
 The player is looking directly at: **{{ crosshairTarget.name }}** ({{ units_to_meters(crosshairTarget.distance) }}m away)
+{% if is_unconscious(crosshairTarget.UUID) %}
+BUT {{ crosshairTarget.name }} is currently unconscious and THEREFORE is unable to reply in any way. Choose another NPC nearby that makes the most sense to reply if one exists.
+{% endif %}
 {% endif %}
 
 {{ "## Recent Dialogue" }}


### PR DESCRIPTION
Two changes for NPC state handling:
- Unconscious state awareness — Adds is_unconscious() checks across 6 prompts so the AI model understands when NPCs are knocked out and unresponsive. Prevents talking to unconscious NPCs, renders scene context, combat status, and dialogue target selection accordingly.
- Empty furniture description fix — When an NPC's furniture string is empty, output was broken ("Bill is interacting with a "). Now falls back to "something" and dynamically handles articles for all furniture types.