### PR TITLE
model-presets: replace Grok with DeepSeek v4 Flash

### DIFF
--- a/model-presets/presets/openrouter-budget.yaml
+++ b/model-presets/presets/openrouter-budget.yaml
@@ -1,5 +1,5 @@
 # Budget preset — Gemma-3 27B for the cheap bulk variants, Qwen 235B
-# for jobs that need more reasoning, and Grok Fast / Qwen-VL for meta
+# for jobs that need more reasoning, and DeepSeek Flash / Qwen-VL for meta
 # and vision. Mod-registered variants inherit the default rotation.
 variants:
   default:
@@ -30,9 +30,9 @@ variants:
     default_params: { temperature: 0.8, max_tokens: 12000 }
 
   UniversalTranslator:
-    model_name: x-ai/grok-4.1-fast
+    model_name: deepseek/deepseek-v4-flash
     model_params:
-      - { name: x-ai/grok-4.1-fast, provider_id: openrouter, temperature: 0.7 }
+      - { name: deepseek/deepseek-v4-flash, provider_id: openrouter, temperature: 0.7 }
     default_params: { temperature: 0.7, max_tokens: 512 }
 
   combat:
@@ -62,9 +62,9 @@ variants:
     default_params: { temperature: 0.7, max_tokens: 4000 }
 
   meta:
-    model_name: x-ai/grok-4.1-fast
+    model_name: deepseek/deepseek-v4-flash
     model_params:
-      - { name: x-ai/grok-4.1-fast, provider_id: openrouter, temperature: 0.7 }
+      - { name: deepseek/deepseek-v4-flash, provider_id: openrouter, temperature: 0.7 }
     default_params: { temperature: 0.7, max_tokens: 100 }
 
   vision:

--- a/model-presets/presets/openrouter-default.yaml
+++ b/model-presets/presets/openrouter-default.yaml
@@ -36,9 +36,9 @@ variants:
     default_params: { temperature: 0.7, max_tokens: 512 }
 
   combat:
-    model_name: x-ai/grok-4-fast
+    model_name: deepseek/deepseek-v4-flash
     model_params:
-      - { name: x-ai/grok-4-fast, provider_id: openrouter, temperature: 0.8 }
+      - { name: deepseek/deepseek-v4-flash, provider_id: openrouter, temperature: 0.8 }
     default_params: { temperature: 0.8, max_tokens: 2000 }
 
   action_evaluation:
@@ -62,9 +62,9 @@ variants:
     default_params: { temperature: 0.7, max_tokens: 4000 }
 
   meta:
-    model_name: x-ai/grok-4-fast
+    model_name: deepseek/deepseek-v4-flash
     model_params:
-      - { name: x-ai/grok-4-fast, provider_id: openrouter, temperature: 0.7 }
+      - { name: deepseek/deepseek-v4-flash, provider_id: openrouter, temperature: 0.7 }
     default_params: { temperature: 0.7, max_tokens: 100 }
 
   vision:

--- a/model-presets/presets/openrouter-performance.yaml
+++ b/model-presets/presets/openrouter-performance.yaml
@@ -1,6 +1,6 @@
 # Performance preset — Sonnet 4.6 for dialogue/profiles/diary/action/
 # memory; DeepSeek 3.2 for combat/gamemaster (faster, still strong);
-# Haiku for the agent; Grok Fast for meta and translator; Qwen VL for
+# Haiku for the agent; DeepSeek Flash for meta and translator; Qwen VL for
 # vision. Higher cost — expect a noticeable bill on heavy sessions.
 # Sonnet runs at temp 1.0 for more variety in dialogue.
 # Mod-registered variants inherit the default rotation.
@@ -33,9 +33,9 @@ variants:
     default_params: { temperature: 1.0, max_tokens: 12000 }
 
   UniversalTranslator:
-    model_name: x-ai/grok-4.1-fast
+    model_name: deepseek/deepseek-v4-flash
     model_params:
-      - { name: x-ai/grok-4.1-fast, provider_id: openrouter, temperature: 0.7 }
+      - { name: deepseek/deepseek-v4-flash, provider_id: openrouter, temperature: 0.7 }
     default_params: { temperature: 0.7, max_tokens: 512 }
 
   combat:
@@ -65,9 +65,9 @@ variants:
     default_params: { temperature: 1.0, max_tokens: 4000 }
 
   meta:
-    model_name: x-ai/grok-4.1-fast
+    model_name: deepseek/deepseek-v4-flash
     model_params:
-      - { name: x-ai/grok-4.1-fast, provider_id: openrouter, temperature: 0.7 }
+      - { name: deepseek/deepseek-v4-flash, provider_id: openrouter, temperature: 0.7 }
     default_params: { temperature: 0.7, max_tokens: 100 }
 
   vision:

--- a/model-presets/recommended-models.yaml
+++ b/model-presets/recommended-models.yaml
@@ -29,20 +29,20 @@ openrouter:
     - id: google/gemma-4-31b-it
 
   meta:
-    - id: x-ai/grok-4.1-fast
+    - id: deepseek/deepseek-v4-flash
     - id: google/gemini-2.5-flash
 
   combat:
-    - id: x-ai/grok-4.1-fast
+    - id: deepseek/deepseek-v4-flash
     - id: deepseek/deepseek-v3.2
     - id: qwen/qwen3-235b-a22b-2507
 
   action_evaluation:
-    - id: x-ai/grok-4.1-fast
+    - id: deepseek/deepseek-v4-flash
     - id: deepseek/deepseek-v3.2
 
   gamemaster_evaluation:
-    - id: x-ai/grok-4.1-fast
+    - id: deepseek/deepseek-v4-flash
     - id: deepseek/deepseek-v3.2
 
   AgentDefault:
@@ -68,7 +68,7 @@ openrouter:
 
   UniversalTranslator:
     - id: google/gemini-2.5-flash
-    - id: x-ai/grok-4.1-fast
+    - id: deepseek/deepseek-v4-flash
 
 nvidia:
   default:
@@ -96,20 +96,20 @@ nanogpt:
     - id: google/gemma-4-31b-it
 
   meta:
-    - id: x-ai/grok-4.1-fast
+    - id: deepseek/deepseek-v4-flash
     - id: gemini-2.5-flash
 
   combat:
-    - id: x-ai/grok-4.1-fast
+    - id: deepseek/deepseek-v4-flash
     - id: deepseek/deepseek-v3.2
     - id: Qwen/Qwen3-235B-A22B-Instruct-2507
 
   action_evaluation:
-    - id: x-ai/grok-4.1-fast
+    - id: deepseek/deepseek-v4-flash
     - id: deepseek/deepseek-v3.2
 
   gamemaster_evaluation:
-    - id: x-ai/grok-4.1-fast
+    - id: deepseek/deepseek-v4-flash
     - id: deepseek/deepseek-v3.2
 
   AgentDefault:
@@ -135,7 +135,7 @@ nanogpt:
 
   UniversalTranslator:
     - id: gemini-2.5-flash
-    - id: x-ai/grok-4.1-fast
+    - id: deepseek/deepseek-v4-flash
 
 chutes:
   default:


### PR DESCRIPTION
## Summary
- Removes all `x-ai/grok-4-fast` and `x-ai/grok-4.1-fast` references from preset rotations and `recommended-models.yaml`, swapping to `deepseek/deepseek-v4-flash`.
- Aligns presets with the Core repo's updated `combat`/`meta` defaults (also being updated there to drop Grok).
- Header comments in `openrouter-performance.yaml` and `openrouter-budget.yaml` updated to reflect the new model.

## Files
- `model-presets/presets/openrouter-default.yaml` — combat + meta
- `model-presets/presets/openrouter-performance.yaml` — UniversalTranslator + meta
- `model-presets/presets/openrouter-budget.yaml` — UniversalTranslator + meta
- `model-presets/recommended-models.yaml` — openrouter + nanogpt entries across meta/combat/action_evaluation/gamemaster_evaluation/UniversalTranslator

## Test plan
- [ ] Load each preset in the dashboard ModelPicker and confirm DeepSeek v4 Flash appears where Grok used to
- [ ] First-run flow picks up `openrouter-default` cleanly
- [ ] No remaining `grep -r grok` hits in `model-presets/`