### PR TITLE
Add Cancel button to diary scope message box

### DIFF
--- a/Source/Scripts/SkyrimNetInternal.psc
+++ b/Source/Scripts/SkyrimNetInternal.psc
@@ -31,6 +31,10 @@ Int Function GetDiaryScopeMessage() global
 
     Int _selection = skynet.libs.msgDiaryScope.Show()
     Debug.Trace("[SkyrimNetInternal] GetDiaryScopeMessage: User selected " + _selection)
+    if _selection == 4
+        Debug.Trace("[SkyrimNetInternal] GetDiaryScopeMessage: User cancelled")
+        return -1
+    endif
     return _selection
 EndFunction
 

--- a/plugins/SkyrimNet/Messages/skynet_DiaryScopeMessage - 0012DC_SkyrimNet.esp.json
+++ b/plugins/SkyrimNet/Messages/skynet_DiaryScopeMessage - 0012DC_SkyrimNet.esp.json
@@ -37,6 +37,12 @@
         "TargetLanguage": "English",
         "Value": "Target in Crosshair"
       }
+    },
+    {
+      "Text": {
+        "TargetLanguage": "English",
+        "Value": "Cancel"
+      }
     }
   ]
 }


### PR DESCRIPTION
# Add Cancel Button to Diary Scope Message Box

## Summary

Adds a "Cancel" button to the `skynet_DiaryScopeMessage` message box, allowing players to dismiss the prompt without selecting any scope option.

## Changes

- **`plugins/SkyrimNet/Messages/skynet_DiaryScopeMessage`** — Added "Cancel" as a fifth menu button (index 4).
- **`Source/Scripts/SkyrimNetInternal.psc`** — `GetDiaryScopeMessage()` now returns `-1` when Cancel is selected (index 4), matching the existing cancelled/error contract.

## Why

Previously the message box had no way to back out — the player was forced to pick one of the four scope options (Player Only, Nearby Actors, Pinned Actors, Target in Crosshair). This is annoying if the dialog is triggered accidentally or the player changes their mind.

## Notes

The existing button labels were left as-is, but a few could be cleaned up in a follow-up pass if desired:

- "Target in Crosshair" → "Crosshair Target" (shorter, consistent casing)
- "Pinned Actors" → "Pinned" (matches the brevity of the other options)
