### PR TITLE
feat(prompts): add vision fallback for textless books

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/omnisight/describe_book_page.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/omnisight/describe_book_page.prompt
@@ -1,0 +1,3 @@
+Analyze this screenshot of a {{ doc_type }} from the game Skyrim. The title is "{{ book_title }}" (editor ID: {{ book_editor_id }}).
+
+Describe what is visually shown: any maps, diagrams, illustrations, decorative elements, visual style. Be concise, 2-3 sentences max.

--- a/SKSE/Plugins/SkyrimNet/prompts/player_thoughts.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/player_thoughts.prompt
@@ -1,7 +1,7 @@
 [ system ]
 You are {{ decnpc(npc.UUID).name }}, a {{ decnpc(npc.UUID).gender }} {{ decnpc(npc.UUID).race }} in Skyrim.
 
-{% if triggeringEvent and triggeringEvent.type == "book_read" %}
+{% if triggeringEvent and (triggeringEvent.type == "book_read" or triggeringEvent.type == "book_read_manual") %}
 {{ render_subcomponent("system_head", "book") }}
 {% else %}
 {{ render_subcomponent("system_head", "thoughts") }}
@@ -82,15 +82,17 @@ You are picking ONE of the listed lines above to say to {% if dialogueSpeaker an
 ## React to Combat
 Think about how this fight feels—the fear or fury, the pain, what drives survival.
 
-{% elif triggeringEvent and triggeringEvent.type == "book_read" %}
+{% elif triggeringEvent and (triggeringEvent.type == "book_read" or triggeringEvent.type == "book_read_manual") %}
 ## React to Reading
 {% if triggeringEvent.data %}
 {% set bookData = triggeringEvent.data %}
 You just finished "{{ bookData.book_title }}".
 {% if bookData.book_text and length(bookData.book_text) > 0 %}
 Contents: {{ bookData.book_text }}
-{% elif bookData.book_vision_description and length(bookData.book_vision_description) > 0 %}
-Visual description (no text found): {{ bookData.book_vision_description }}
+{% endif %}
+{% if bookData.book_vision_description and length(bookData.book_vision_description) > 0 %}
+
+Visual details: {{ bookData.book_vision_description }}
 {% endif %}
 {% endif %}
 What does this mean to you? How does it relate to your situation?

--- a/SKSE/Plugins/SkyrimNet/prompts/player_thoughts.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/player_thoughts.prompt
@@ -89,6 +89,8 @@ Think about how this fight feels—the fear or fury, the pain, what drives survi
 You just finished "{{ bookData.book_title }}".
 {% if bookData.book_text and length(bookData.book_text) > 0 %}
 Contents: {{ bookData.book_text }}
+{% elif bookData.book_vision_description and length(bookData.book_vision_description) > 0 %}
+Visual description (no text found): {{ bookData.book_vision_description }}
 {% endif %}
 {% endif %}
 What does this mean to you? How does it relate to your situation?

--- a/docs/modding/WORKFLOW_TRIGGERS.md
+++ b/docs/modding/WORKFLOW_TRIGGERS.md
@@ -227,6 +227,7 @@ mcp_skyrimnet-mcp_validate_custom_trigger:
 | `equip` | Equipment change | `actor`, `item`, `action`, `equipped` |
 | `sleep_start` / `sleep_stop` | Sleep events | `actor` |
 | `book_read` | Book reading | `book_name`, `book_title`, `book_text` |
+| `book_read_manual` | Capture Crosshair hotkey book event - emitted once after Book Menu closes for first accepted capture in session | `book_name`, `book_title`, `book_text`, `book_vision_description` |
 | `quest_stage` | Quest progression | `quest`, `quest_id`, `stage` |
 | `quest_start_stop` | Quest start/end | `quest`, `quest_id`, `started` (boolean) |
 | `location_change` | Location changed | `actor`, `from_location`, `to_location` |


### PR DESCRIPTION
Paired with MinLL/SkyrimNet#839.

This adds the prompt-side support for manual/textless book capture.

What changed:

- Added omnisight/describe_book_page.prompt, used by the core DLL when a manually captured book has no meaningful extractable text.
- Updated player_thoughts.prompt so ook_vision_description is rendered when ook_text is empty.
- Keeps text-based books on the normal ook_text path, while maps/diagrams/image-only pages can still give the LLM usable visual context.

Notes:

- The original core PR MinLL/SkyrimNet#815 was merged.
- MinLL/SkyrimNet#839 is the current clean implementation that uses the dedicated ook_read_manual event (supersedes #830).
- MinLL/SkyrimNet#830 is superseded and no longer the active review target.
- This PR MUST merge alongside #839 so the core vision capture path has the prompt assets it calls for ook_vision_description.

Verification:

- GamePlugin checks are passing on GitHub.
- Core paired PR #839 passes full release build and 741/741 tests.
- In-game manual book capture worked after the latest paired core commit.