### PR TITLE
feat: Quest Journal Decorator Integration (Prompt Pair)

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0610_party_quests.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0610_party_quests.prompt
@@ -1,0 +1,40 @@
+{% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" %}
+{% if is_follower(actorUUID) or actorUUID == player.UUID %}
+{% set tracked_quests = get_selected_quests() %}
+{% set journal = get_quest_journal() %}
+{% set show_misc_tasks = show_misc_tasks | default(true) %}
+{% set show_inactive_quests = show_inactive_quests | default(false) %}
+{% if length(tracked_quests) > 0 %}
+{% if is_follower(actorUUID) %}## {{ player.name }}'s Party's Active Quests{% else %}## Active Quests{% endif %}
+(Quests remain available indefinitely unless explicitly stated otherwise. Do NOT create urgency, invent deadlines, or repeatedly remind about objectives.)
+{% for quest in tracked_quests %}
+{% for jq in journal %}{% if jq.editorID == quest.editorID %}
+{% if jq.journalText and not jq.isMisc %}
+**{{ jq.questName }}**
+{{ jq.journalText }}
+{% for obj in jq.objectives %}{% if obj.displayed %}{% if obj.completed %}
+- {{ obj.text }} [DONE]{% elif not obj.failed %}
+- {{ obj.text }}{% endif %}{% endif %}{% endfor %}
+
+{% endif %}
+{% endif %}{% endfor %}
+{% endfor %}
+{% if show_inactive_quests %}
+{% for jq in journal %}{% if jq.inQuestLog %}{% if jq.journalText %}
+**{{ jq.questName }}** (inactive)
+{{ jq.journalText }}
+{% endif %}{% endif %}{% endfor %}
+{% endif %}
+{% if show_misc_tasks %}
+### Misc. Tasks
+{% for quest in tracked_quests %}
+{% for jq in journal %}{% if jq.editorID == quest.editorID %}{% if jq.isMisc %}{% for obj in jq.objectives %}{% if obj.displayed and not obj.completed and not obj.failed %}
+- {{ obj.text }}{% endif %}{% endfor %}{% endif %}{% endif %}{% endfor %}
+{% endfor %}
+{% endif %}
+{% else %}
+## {{ player.name }}'s Party's Active Quests
+No active quests currently tracked.
+{% endif %}
+{% endif %}
+{% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0600_quest_gamesystem_decorators.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0600_quest_gamesystem_decorators.prompt
@@ -498,3 +498,117 @@ First 10 Plugins: {{ join(allPlugins, ", ") }}
 
 ---
 
+### Test 16: get_quest_journal() - Resolved Journal Data
+{# Returns JSON array of active quests with resolved objective text and journal entries #}
+{# Each entry: questName, editorID, stage, questType, isMisc, inQuestLog, objectives[{text,completed,failed,displayed}], journalText #}
+
+{% set journal = get_quest_journal() %}
+**Total Journal Entries:** {{ length(journal) }}
+
+{% if journal and length(journal) > 0 %}
+{% set firstEntry = first(journal) %}
+
+**First Entry Inspection:**
+- questName: "{{ firstEntry.questName }}"
+- editorID: {{ firstEntry.editorID }}
+- stage: {{ firstEntry.stage }}
+- questType: {{ firstEntry.questType }}
+- isMisc: {{ firstEntry.isMisc }}
+- inQuestLog: {{ firstEntry.inQuestLog }}
+- journalText: {% if firstEntry.journalText %}"{{ firstEntry.journalText }}" ✓{% else %}(none){% endif %}
+- objectives: {% if firstEntry.objectives and length(firstEntry.objectives) >0 %}{{ length(firstEntry.objectives) }} entries{% else %}(none){% endif %}
+
+**Type Validation:**
+- is_array(journal): {% if journal and is_array(journal) %}✓ YES{% else %}✗ NO{% endif %}
+- questName is string: {% if firstEntry.questName %}✓{% else %}✗{% endif %}
+- isMisc is bool: {% if firstEntry.isMisc == true or firstEntry.isMisc == false %}✓{% else %}✗{% endif %}
+- inQuestLog is bool: {% if firstEntry.inQuestLog == true or firstEntry.inQuestLog == false %}✓{% else %}✗{% endif %}
+- stage is number: {% if firstEntry.stage >= 0 %}✓{% else %}✗{% endif %}
+- questType is number: {% if firstEntry.questType >= 0 %}✓{% else %}✗{% endif %}
+
+**Objective Structure (first quest with objectives):**
+{% for jq in journal %}
+{% if loop.index == 1 and jq.objectives and length(jq.objectives) > 0 %}
+{% set firstObj = first(jq.objectives) %}
+- Quest: {{ jq.editorID }}
+  - text: "{{ firstObj.text }}"
+  - displayed: {{ firstObj.displayed }}
+  - completed: {{ firstObj.completed }}
+  - failed: {{ firstObj.failed }}
+{% endif %}
+{% endfor %}
+
+**Objective Listing (first quest with objectives):**
+{% for jq in journal %}
+{% if loop.index == 1 and jq.objectives and length(jq.objectives) > 0 %}
+{% for obj in jq.objectives %}
+{% if loop.index <= 3 %}
+  - [{{ loop.index }}] "{{ obj.text }}" (disp:{{ obj.displayed }}, done:{{ obj.completed }}, fail:{{ obj.failed }})
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+
+**Cross-Reference with get_selected_quests():**
+{% set selectedQuests = get_selected_quests() %}
+- {{ length(selectedQuests) }} selected quests, {{ length(journal) }} journal entries
+{% if selectedQuests and length(selectedQuests) > 0 %}
+{% for sq in selectedQuests %}
+{% if loop.index <= 5 %}
+{% set matched = false %}
+{% for jq in journal %}
+{% if not matched and jq.editorID == sq.editorID %}{% set matched = true %}{% endif %}
+{% endfor %}
+- {{ sq.editorID }} ({{ sq.name }}): {% if matched %}✓ in journal{% else %}✗ not in journal{% endif %}
+{% endif %}
+{% endfor %}
+{% else %}
+- No selected quests to cross-reference.
+{% endif %}
+
+**Content Summary:**
+{% set totalDisplayed = 0 %}{% set totalCompleted = 0 %}{% set totalFailed = 0 %}
+{% set miscCount = 0 %}{% set withJournalText = 0 %}
+{% for jq in journal %}
+{% if jq.isMisc %}{% set miscCount = miscCount + 1 %}{% endif %}
+{% if jq.journalText %}{% set withJournalText = withJournalText + 1 %}{% endif %}
+{% if jq.objectives and length(jq.objectives) > 0 %}
+{% for obj in jq.objectives %}
+{% if obj.displayed %}{% set totalDisplayed = totalDisplayed + 1 %}{% endif %}
+{% if obj.completed %}{% set totalCompleted = totalCompleted + 1 %}{% endif %}
+{% if obj.failed %}{% set totalFailed = totalFailed + 1 %}{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+- Misc quests: {{ miscCount }}
+- Quests with journal text: {{ withJournalText }}/{{ length(journal) }}
+- Displayed objectives: {{ totalDisplayed }}
+- Completed objectives: {{ totalCompleted }}
+- Failed objectives: {{ totalFailed }}
+
+**Specific Quest Lookups:**
+{% set hasMQ101 = false %}{% set hasMainQuest = false %}
+{% for jq in journal %}
+{% if jq.editorID == "MQ101" %}{% set hasMQ101 = true %}{% endif %}
+{% if jq.editorID == "MQ102" or jq.editorID == "MQ103" or jq.editorID == "MQ104" %}{% set hasMainQuest = true %}{% endif %}
+{% endfor %}
+- MQ101 in journal: {% if hasMQ101 %}✓ YES{% else %}✗ NO (not started or filtered){% endif %}
+- Main quest (MQ102/MQ103/MQ104) in journal: {% if hasMainQuest %}✓ YES{% else %}✗ NO{% endif %}
+
+**Default Call Idempotency:**
+{% set journalDefault = get_quest_journal() %}
+- Same result count: {% if length(journalDefault) == length(journal) %}✓ YES{% else %}✗ different{% endif %}
+
+{% for jq in journal %}
+{% if loop.index <= 3 %}
+**Quest {{ loop.index }} in list:** {{ jq.questName }} ({{ jq.editorID }})
+  - Stage {{ jq.stage }}, Misc={{ jq.isMisc }}, Log={{ jq.inQuestLog }}
+{% endif %}
+{% endfor %}
+
+{% else %}
+No journal entries found.
+{% endif %}
+
+---
+


### PR DESCRIPTION
**Paired with [Gerkinfeltser/SkyrimNet#816](https://github.com/MinLL/SkyrimNet/pull/816) (quest journal decorator integration) — merge together for full functionality.**

## Problem

The existing quest decorators return raw engine data with unresolved tokens (`<Alias=...>`, `<Global=...>`), making quest objectives unreadable in LLM prompts. A new `get_quest_journal()` decorator is being added to the main DLL that resolves these tokens and provides journal body text.

## Solution

Adds the `0610_party_quests.prompt` template that uses `get_quest_journal()` to render resolved quest journal content in character bios.

## Changes

**`SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0610_party_quests.prompt`** (new file, 42 lines)
- Uses `get_quest_journal()` to get fully resolved quest data
- Cross-references `get_selected_quests()` with `get_quest_journal()` for tracked quests
- **Main quests**: resolved quest name, journal narrative text, displayed objectives with `[DONE]` markers
- **Misc tasks**: flat list of displayed non-completed objectives
- **Inactive section** (disabled by default): quests in player's questLog with journal text
- Configurable via `show_misc_tasks` and `show_inactive_quests` template variables
- Modified from prompt originally by jykej

## Dependency

Requires the SkyrimNet DLL with the quest journal decorator registered (paired PR above). Without it, `get_quest_journal()` returns an empty array and the template falls back to "No active quests currently tracked."

## Example Output

```
## Active Quests
(Quests remain available indefinitely unless explicitly stated otherwise.)

**Dampened Spirits**
Now that Mallus's position as the owner of Honningbrew Meadery has been secured, I need to find any information explaining how Sabjorn was able to fund this costly operation.
- Speak to Maven Black-Briar [DONE]
- Speak to Mallus Maccius at the Bannered Mare in Whiterun [DONE]
- Search Sabjorn's dresser for information about his silent partner

**Balance of Power**
I spoke to Ri'saad, the traveling caravan merchant, about trouble along the road. He handed me a note that has more details.
- Read Ri'saad's note

### Misc. Tasks
- Learn more about the Thieves Guild from Delvin
- Get 3 flawless amethysts for Talen-Jei (0/3)
- Return the Honningbrew Decanter to Delvin
```
