### PR TITLE
prompt: consolidate quest context rendering

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/components/character_bio_full.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/character_bio_full.prompt
@@ -24,12 +24,3 @@
 
 ## Speech Style
 {% block speech_style %}{% endblock %}
-
-## General World Knowledge
-{% block quest_integrations %}
-{% for quest in get_all_active_quests() %}
-    {% if quest.editorID and prompt_file_exists(quest.editorID, "quests") %}
-        {{ render_quest_template(quest.editorID) }}
-    {% endif %}
-{% endfor %}
-{% endblock %}

--- a/SKSE/Plugins/SkyrimNet/prompts/player_thoughts.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/player_thoughts.prompt
@@ -61,18 +61,6 @@ Express a genuine {{ decnpc(npc.UUID).name }} thought on this topic:
 ---
 
 {% endif %}
-{% set selectedQuests = get_selected_quests() %}
-{% if selectedQuests and length(selectedQuests) > 0 %}
-## Active Quests
-{% for quest in selectedQuests %}
-{% if quest.name == "IntelEngine" %}
-{{ get_intelengine_quests(npc.UUID) }}
-{% else %}
-**{{ quest.name }}** ({{ quest.type }}):{% for objective in quest.objectives %} {{ objective.objectiveText }}{% if objective.isCompleted %} (Done){% endif %}{% if not loop.is_last %};{% endif %}{% endfor %}
-{% endif %}
-{% endfor %}
-{% endif %}
-
 {% if dialogue_options and length(dialogue_options) > 0 %}
 ## REMINDER: Choose Your Reply
 You are picking ONE of the listed lines above to say to {% if dialogueSpeaker and dialogueSpeaker.name and length(dialogueSpeaker.name) > 0 %}{{ dialogueSpeaker.name }}{% else %}the person in front of you{% endif %}. Your reasoning is the silent thought that justifies the pick — feel the moment, but stay focused on the choice.

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0610_party_quests.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0610_party_quests.prompt
@@ -8,6 +8,9 @@
 {% if is_follower(actorUUID) %}## {{ player.name }}'s Party's Active Quests{% else %}## Active Quests{% endif %}
 (Quests remain available indefinitely unless explicitly stated otherwise. Do NOT create urgency, invent deadlines, or repeatedly remind about objectives.)
 {% for quest in tracked_quests %}
+{% if quest.name == "IntelEngine" %}
+{{ get_intelengine_quests(npc.UUID) }}
+{% else %}
 {% for jq in journal %}{% if jq.editorID == quest.editorID %}
 {% if jq.journalText and not jq.isMisc %}
 **{{ jq.questName }}**
@@ -18,6 +21,7 @@
 
 {% endif %}
 {% endif %}{% endfor %}
+{% endif %}
 {% endfor %}
 {% if show_inactive_quests %}
 {% for jq in journal %}{% if jq.inQuestLog %}{% if jq.journalText %}


### PR DESCRIPTION
Consolidate quest rendering so player/follower thought prompts no longer duplicate quest output.

- Remove the inline quest block from `player_thoughts.prompt`
- Remove the legacy `quest_integrations` block from `components/character_bio_full.prompt`
- Keep quest output centralized in `0610_party_quests.prompt`
- Preserve the `IntelEngine` special-case path inside the party quest renderer

This avoids duplicate quest context in thoughts while keeping the existing party quest behavior intact.