### PR TITLE
update budget preset and rename Performance

### DIFF
--- a/model-presets/index.yaml
+++ b/model-presets/index.yaml
@@ -16,6 +16,6 @@ presets:
     file: presets/openrouter-default.yaml
 
   - id: openrouter-performance
-    name: Performance
+    name: Premium
     provider: openrouter
     file: presets/openrouter-performance.yaml

--- a/model-presets/presets/openrouter-budget.yaml
+++ b/model-presets/presets/openrouter-budget.yaml
@@ -36,7 +36,7 @@ variants:
     default_params: { temperature: 0.7, max_tokens: 512 }
 
   combat:
-    model_name: google/gemma-4-31b-it
+    model_name: google/gemma-4-26b-a4b-it
     model_params:
       - { name: google/gemma-4-31b-it, provider_id: openrouter, temperature: 0.8 }
     default_params: { temperature: 0.8, max_tokens: 2000 }
@@ -48,7 +48,7 @@ variants:
     default_params: { temperature: 0.7, max_tokens: 500 }
 
   gamemaster_evaluation:
-    model_name: google/gemma-4-31b-it
+    model_name: meta-llama/llama-3.3-70b-instruct
     timeout: 30
     model_params:
       - { name: google/gemma-4-31b-it, provider_id: openrouter, temperature: 0.8 }
@@ -68,7 +68,7 @@ variants:
     default_params: { temperature: 0.7, max_tokens: 100 }
 
   vision:
-    model_name: qwen/qwen3-vl-235b-a22b-instruct
+    model_name: qwen/qwen3-vl-8b-instruct
     model_params:
-      - { name: qwen/qwen3-vl-235b-a22b-instruct, provider_id: openrouter, temperature: 0.7 }
+      - { name: qwen/qwen3-vl-8b-instruct, provider_id: openrouter, temperature: 0.7 }
     default_params: { temperature: 0.7, max_tokens: 4000 }

--- a/model-presets/presets/openrouter-budget.yaml
+++ b/model-presets/presets/openrouter-budget.yaml
@@ -38,7 +38,7 @@ variants:
   combat:
     model_name: google/gemma-4-26b-a4b-it
     model_params:
-      - { name: google/gemma-4-31b-it, provider_id: openrouter, temperature: 0.8 }
+      - { name: google/gemma-4-26b-a4b-it, provider_id: openrouter, temperature: 0.8 }
     default_params: { temperature: 0.8, max_tokens: 2000 }
 
   action_evaluation:
@@ -51,7 +51,7 @@ variants:
     model_name: meta-llama/llama-3.3-70b-instruct
     timeout: 30
     model_params:
-      - { name: google/gemma-4-31b-it, provider_id: openrouter, temperature: 0.8 }
+      - { name: meta-llama/llama-3.3-70b-instruct, provider_id: openrouter, temperature: 0.8 }
     default_params: { temperature: 0.8, max_tokens: 256 }
 
   memory:


### PR DESCRIPTION
Updated the budget preset and renamed the Performance preset to Premium

Budget preset:
Vision swapped `qwen/qwen3-vl-8b-instruct`
gamemaster swapped to Balanced's `meta-llama/llama-3.3-70b-instruct`
combat swapped to `google/gemma-4-26b-a4b-it`