### PR TITLE
Dashboard access from Papyrus: MCM hotkey + wheel menu "Open Dashboard"

### DIFF
--- a/Source/Scripts/SkyrimNetApi.psc
+++ b/Source/Scripts/SkyrimNetApi.psc
@@ -543,6 +543,25 @@ int function TriggerToggleActions() Global Native
 ; Functions identically to pressing the configured whisper toggle key
 int function TriggerToggleWhisperMode() Global Native
 
+; Toggles the in-game PrismaUI dashboard overlay (open if closed, close if open)
+; - Honors the same guards as the C++ dashboard hotkey: no-op while the chat
+;   overlay is open; on open, applies crosshair-target navigation per the
+;   Dashboard config (enabled / shift / disabled)
+; - Works regardless of whether C++ hotkeys are enabled, so VR users running
+;   in-game (Papyrus) hotkeys can still reach the dashboard via the wheel menu
+;   or a bound key
+; Returns 0 on success, 1 on failure
+int function TriggerToggleDashboard() Global Native
+
+; Tell the dashboard's input sink which key/button currently toggles the
+; dashboard (the in-game hotkey's keycode), so it can close the dashboard while
+; it's open. While the dashboard owns input focus the normal Papyrus OnKeyDown
+; is suppressed, so the key alone can't close it; the input sink handles that.
+; Pass -1 to disable (e.g. when in-game hotkeys are turned off).
+; - keyCode: DXScanCode (keyboard) or gamepad keycode, same as RegisterForKey
+; Returns 0 on success, 1 on failure
+int function SetDashboardToggleKey(int keyCode) Global Native
+
 ; --- Thought System Functions ---
 
 ; Simulates pressing the text thought hotkey

--- a/Source/Scripts/skynet_Library.psc
+++ b/Source/Scripts/skynet_Library.psc
@@ -586,6 +586,7 @@ Int Property hotkeyToggleOpenMic = -1 Auto Hidden
 Int Property hotkeyCaptureCrosshair = -1 Auto Hidden
 Int Property hotkeyGenerateDiaryBio = -1 Auto Hidden
 Int Property hotkeyInterruptDialogue = -1 Auto Hidden
+Int Property hotkeyOpenDashboard = -1 Auto Hidden
 
 Bool Property inGameHotkeysEnabled = false Auto Hidden
 
@@ -677,6 +678,12 @@ Function RegisterConfiguredHotkeys()
     If hotkeyInterruptDialogue != -1
         RegisterForKey(hotkeyInterruptDialogue)
     EndIf
+    ; The dashboard toggle is deliberately NOT a RegisterForKey hotkey. Once the
+    ; dashboard owns input focus Skyrim suppresses its OnKeyDown, so a key hotkey
+    ; could only ever open it, never close it. Instead the key/button is handed
+    ; to the dashboard's input sink, which sees raw keyboard + controller input
+    ; regardless of focus and toggles it open AND closed. -1 (unbound) disables.
+    SkyrimNetApi.SetDashboardToggleKey(hotkeyOpenDashboard)
 EndFunction
 
 Function UnregisterAllHotkeys()
@@ -723,6 +730,9 @@ Function UnregisterAllHotkeys()
     If hotkeyInterruptDialogue != -1
         UnregisterForKey(hotkeyInterruptDialogue)
     EndIf
+    ; Clear the sink's toggle key. In native-hotkey mode the C++ hotkey owns the
+    ; dashboard toggle (OS-level key polling), so the sink stays idle.
+    SkyrimNetApi.SetDashboardToggleKey(-1)
 EndFunction
 
 Function EnableInGameHotkeys()
@@ -865,6 +875,9 @@ Function HandleHotkeyPress(Int keyCode)
     ElseIf keyCode == hotkeyInterruptDialogue && hotkeyInterruptDialogue != -1
         SkyrimNetApi.TriggerInterruptDialogue()
     EndIf
+    ; Note: the dashboard toggle is intentionally absent here — it's driven by
+    ; the dashboard's input sink (SetDashboardToggleKey), not RegisterForKey, so
+    ; it can close while open. See RegisterConfiguredHotkeys.
 EndFunction
 
 Function HandleHotkeyRelease(Int keyCode, Float holdTime)

--- a/Source/Scripts/skynet_McmScript.psc
+++ b/Source/Scripts/skynet_McmScript.psc
@@ -44,6 +44,7 @@ int optionHotkeyToggleOpenMic
 int optionHotkeyCaptureCrosshair
 int optionHotkeyGenerateDiaryBio
 int optionHotkeyInterruptDialogue
+int optionHotkeyOpenDashboard
 
 int useImage
 
@@ -303,6 +304,7 @@ function DisplayHotkeys()
         optionHotkeyToggleWorldEventReactions = AddKeyMapOption("Toggle World Events", library.hotkeyToggleWorldEventReactions)
         optionHotkeyToggleWhisperMode = AddKeyMapOption("Toggle Whisper Mode", library.hotkeyToggleWhisperMode)
         optionHotkeyToggleOpenMic = AddKeyMapOption("Toggle Open Mic", library.hotkeyToggleOpenMic)
+        optionHotkeyOpenDashboard = AddKeyMapOption("Open Dashboard", library.hotkeyOpenDashboard)
         
         AddHeaderOption("Other Hotkeys")
         AddHeaderOption("")
@@ -1187,6 +1189,9 @@ event OnOptionKeyMapChange(int option, int keyCode, string conflictControl, stri
     elseif option == optionHotkeyInterruptDialogue
         library.hotkeyInterruptDialogue = finalKeyCode
         SetKeyMapOptionValue(option, keyCode)
+    elseif option == optionHotkeyOpenDashboard
+        library.hotkeyOpenDashboard = finalKeyCode
+        SetKeyMapOptionValue(option, keyCode)
     endif
 
     ; Re-register hotkeys to pick up the change immediately
@@ -1194,7 +1199,7 @@ event OnOptionKeyMapChange(int option, int keyCode, string conflictControl, stri
         library.UnregisterAllHotkeys()
         library.RegisterConfiguredHotkeys()
     endif
-    
+
 endevent
 
 event OnOptionDefault(int option)
@@ -1243,6 +1248,9 @@ event OnOptionDefault(int option)
     elseif option == optionHotkeyInterruptDialogue
         library.hotkeyInterruptDialogue = -1
         SetKeyMapOptionValue(option, -1)
+    elseif option == optionHotkeyOpenDashboard
+        library.hotkeyOpenDashboard = -1
+        SetKeyMapOptionValue(option, -1)
     endif
 
     ; Re-register hotkeys to pick up the change immediately
@@ -1250,7 +1258,7 @@ event OnOptionDefault(int option)
         library.UnregisterAllHotkeys()
         library.RegisterConfiguredHotkeys()
     endif
-    
+
 endevent
 
 ; ============================================================================

--- a/Source/Scripts/skynet_WheelMenu.psc
+++ b/Source/Scripts/skynet_WheelMenu.psc
@@ -10,10 +10,21 @@ EndEvent
 ; Text input modes (Think, Transform, Direct, Silent) are handled via prefixes in the PrismaUI chat
 Function DisplayWheel() global
 
-    string labels = "Text Input,Think to Self,Auto Roleplay,Toggle Whisper Mode,Utilities"
-    string options = "Text Input,Think to Self,Auto Roleplay,Toggle Whisper Mode,Utilities Menu"
+    ; Build with explicit slot indices (UIWheelMenu has 8 fixed wedges, 0-7).
+    ; Slots 0-4 keep the original layout so existing muscle memory holds; slot 5
+    ; is left as a gap and Open Dashboard sits at slot 6 (past Utilities) so the
+    ; new entry doesn't shove the original cluster around.
+    UIMenuBase wheelMenu = uiextensions.GetMenu("UIWheelMenu")
+    wheelMenu = skynet_WheelMenu.SetWheelEntry(wheelMenu, 0, "Text Input", "Text Input")
+    wheelMenu = skynet_WheelMenu.SetWheelEntry(wheelMenu, 1, "Think to Self", "Think to Self")
+    wheelMenu = skynet_WheelMenu.SetWheelEntry(wheelMenu, 2, "Auto Roleplay", "Auto Roleplay")
+    wheelMenu = skynet_WheelMenu.SetWheelEntry(wheelMenu, 3, "Toggle Whisper Mode", "Toggle Whisper Mode")
+    wheelMenu = skynet_WheelMenu.SetWheelEntry(wheelMenu, 4, "Utilities", "Utilities Menu")
+    wheelMenu = skynet_WheelMenu.SetWheelEntry(wheelMenu, 5, "", "", false)
+    wheelMenu = skynet_WheelMenu.SetWheelEntry(wheelMenu, 6, "Open Dashboard", "Open Dashboard")
+    wheelMenu = skynet_WheelMenu.SetWheelEntry(wheelMenu, 7, "", "", false)
 
-    int result = skynet_WheelMenu.MenuWheel(StringUtil.Split(options, ","), StringUtil.Split(labels, ","))
+    int result = wheelMenu.OpenMenu()
 
     if result == 0
         ; Text input — use prefixes for modes: % Think, ' Transform, ! Direct, /silent Silent
@@ -30,6 +41,11 @@ Function DisplayWheel() global
     elseif result == 4
         ; Utilities submenu
         skynet_WheelMenu.DisplayUtilities()
+    elseif result == 6
+        ; Toggle the in-game dashboard. Note: UIExtensions menus generally don't
+        ; render in VR, so the bindable "Open Dashboard" Papyrus hotkey is the
+        ; real VR path — this wheel entry is the convenience path for flatrim.
+        SkyrimNetApi.TriggerToggleDashboard()
     endif
 
 EndFunction


### PR DESCRIPTION
## Summary
Papyrus/esp counterpart to SkyrimNet-Dev `dashboard-papyrus-access`. Lets players open the in-game dashboard without a keyboard.

## Changes
- **Wheel menu:** new top-level **Open Dashboard** entry.
- **MCM:** bindable dashboard hotkey. The bound key is registered with the plugin via `SkyrimNetApi.SetDashboardToggleKey` (plus the C++-hotkeys-enabled handshake), so it toggles the dashboard open and closed even while Papyrus owns the rest of the hotkeys.

## Pairs with
https://github.com/MinLL/SkyrimNet/pull/838