### PR TITLE
fix: restore quest journal prompts for DLL #851

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/components/character_bio_full.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/character_bio_full.prompt
@@ -24,12 +24,3 @@
 
 ## Speech Style
 {% block speech_style %}{% endblock %}
-
-## General World Knowledge
-{% block quest_integrations %}
-{% for quest in get_all_active_quests() %}
-    {% if quest.editorID and prompt_file_exists(quest.editorID, "quests") %}
-        {{ render_quest_template(quest.editorID) }}
-    {% endif %}
-{% endfor %}
-{% endblock %}

--- a/SKSE/Plugins/SkyrimNet/prompts/player_thoughts.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/player_thoughts.prompt
@@ -61,18 +61,6 @@ Express a genuine {{ decnpc(npc.UUID).name }} thought on this topic:
 ---
 
 {% endif %}
-{% set selectedQuests = get_selected_quests() %}
-{% if selectedQuests and length(selectedQuests) > 0 %}
-## Active Quests
-{% for quest in selectedQuests %}
-{% if quest.name == "IntelEngine" %}
-{{ get_intelengine_quests(npc.UUID) }}
-{% else %}
-**{{ quest.name }}** ({{ quest.type }}):{% for objective in quest.objectives %} {{ objective.objectiveText }}{% if objective.isCompleted %} (Done){% endif %}{% if not loop.is_last %};{% endif %}{% endfor %}
-{% endif %}
-{% endfor %}
-{% endif %}
-
 {% if dialogue_options and length(dialogue_options) > 0 %}
 ## REMINDER: Choose Your Reply
 You are picking ONE of the listed lines above to say to {% if dialogueSpeaker and dialogueSpeaker.name and length(dialogueSpeaker.name) > 0 %}{{ dialogueSpeaker.name }}{% else %}the person in front of you{% endif %}. Your reasoning is the silent thought that justifies the pick — feel the moment, but stay focused on the choice.

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0610_party_quests.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0610_party_quests.prompt
@@ -1,0 +1,44 @@
+{% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" %}
+{% if is_follower(actorUUID) or actorUUID == player.UUID %}
+{% set tracked_quests = get_selected_quests() %}
+{% set journal = get_quest_journal() %}
+{% set show_misc_tasks = show_misc_tasks | default(true) %}
+{% set show_inactive_quests = show_inactive_quests | default(false) %}
+{% if length(tracked_quests) > 0 %}
+{% if is_follower(actorUUID) %}## {{ player.name }}'s Party's Active Quests{% else %}## Active Quests{% endif %}
+(Quests remain available indefinitely unless explicitly stated otherwise. Do NOT create urgency, invent deadlines, or repeatedly remind about objectives.)
+{% for quest in tracked_quests %}
+{% if quest.name == "IntelEngine" %}
+{{ get_intelengine_quests(npc.UUID) }}
+{% else %}
+{% for jq in journal %}{% if jq.editorID == quest.editorID %}
+{% if jq.journalText and not jq.isMisc %}
+**{{ jq.questName }}**
+{{ jq.journalText }}
+{% for obj in jq.objectives %}{% if obj.displayed %}{% if obj.completed %}
+- {{ obj.text }} [DONE]{% elif not obj.failed %}
+- {{ obj.text }}{% endif %}{% endif %}{% endfor %}
+
+{% endif %}
+{% endif %}{% endfor %}
+{% endif %}
+{% endfor %}
+{% if show_inactive_quests %}
+{% for jq in journal %}{% if jq.inQuestLog %}{% if jq.journalText %}
+**{{ jq.questName }}** (inactive)
+{{ jq.journalText }}
+{% endif %}{% endif %}{% endfor %}
+{% endif %}
+{% if show_misc_tasks %}
+### Misc. Tasks
+{% for quest in tracked_quests %}
+{% for jq in journal %}{% if jq.editorID == quest.editorID %}{% if jq.isMisc %}{% for obj in jq.objectives %}{% if obj.displayed and not obj.completed and not obj.failed %}
+- {{ obj.text }}{% endif %}{% endfor %}{% endif %}{% endif %}{% endfor %}
+{% endfor %}
+{% endif %}
+{% else %}
+## {{ player.name }}'s Party's Active Quests
+No active quests currently tracked.
+{% endif %}
+{% endif %}
+{% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0600_quest_gamesystem_decorators.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0600_quest_gamesystem_decorators.prompt
@@ -498,8 +498,117 @@ First 10 Plugins: {{ join(allPlugins, ", ") }}
 
 ---
 
-### Test 16: get_quest_journal() - Disabled Pending Fix
-get_quest_journal() is temporarily disabled in the DLL and this decorator test is skipped until the decorator is restored.
+### Test 16: get_quest_journal() - Resolved Journal Data
+{# Returns JSON array of active quests with resolved objective text and journal entries #}
+{# Each entry: questName, editorID, stage, questType, isMisc, inQuestLog, objectives[{text,completed,failed,displayed}], journalText #}
+
+{% set journal = get_quest_journal() %}
+**Total Journal Entries:** {{ length(journal) }}
+
+{% if journal and length(journal) > 0 %}
+{% set firstEntry = first(journal) %}
+
+**First Entry Inspection:**
+- questName: "{{ firstEntry.questName }}"
+- editorID: {{ firstEntry.editorID }}
+- stage: {{ firstEntry.stage }}
+- questType: {{ firstEntry.questType }}
+- isMisc: {{ firstEntry.isMisc }}
+- inQuestLog: {{ firstEntry.inQuestLog }}
+- journalText: {% if firstEntry.journalText %}"{{ firstEntry.journalText }}" ✓{% else %}(none){% endif %}
+- objectives: {% if firstEntry.objectives and length(firstEntry.objectives) >0 %}{{ length(firstEntry.objectives) }} entries{% else %}(none){% endif %}
+
+**Type Validation:**
+- is_array(journal): {% if journal and is_array(journal) %}✓ YES{% else %}✗ NO{% endif %}
+- questName is string: {% if firstEntry.questName %}✓{% else %}✗{% endif %}
+- isMisc is bool: {% if firstEntry.isMisc == true or firstEntry.isMisc == false %}✓{% else %}✗{% endif %}
+- inQuestLog is bool: {% if firstEntry.inQuestLog == true or firstEntry.inQuestLog == false %}✓{% else %}✗{% endif %}
+- stage is number: {% if firstEntry.stage >= 0 %}✓{% else %}✗{% endif %}
+- questType is number: {% if firstEntry.questType >= 0 %}✓{% else %}✗{% endif %}
+
+**Objective Structure (first quest with objectives):**
+{% for jq in journal %}
+{% if loop.index == 1 and jq.objectives and length(jq.objectives) > 0 %}
+{% set firstObj = first(jq.objectives) %}
+- Quest: {{ jq.editorID }}
+  - text: "{{ firstObj.text }}"
+  - displayed: {{ firstObj.displayed }}
+  - completed: {{ firstObj.completed }}
+  - failed: {{ firstObj.failed }}
+{% endif %}
+{% endfor %}
+
+**Objective Listing (first quest with objectives):**
+{% for jq in journal %}
+{% if loop.index == 1 and jq.objectives and length(jq.objectives) > 0 %}
+{% for obj in jq.objectives %}
+{% if loop.index <= 3 %}
+  - [{{ loop.index }}] "{{ obj.text }}" (disp:{{ obj.displayed }}, done:{{ obj.completed }}, fail:{{ obj.failed }})
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+
+**Cross-Reference with get_selected_quests():**
+{% set selectedQuests = get_selected_quests() %}
+- {{ length(selectedQuests) }} selected quests, {{ length(journal) }} journal entries
+{% if selectedQuests and length(selectedQuests) > 0 %}
+{% for sq in selectedQuests %}
+{% if loop.index <= 5 %}
+{% set matched = false %}
+{% for jq in journal %}
+{% if not matched and jq.editorID == sq.editorID %}{% set matched = true %}{% endif %}
+{% endfor %}
+- {{ sq.editorID }} ({{ sq.name }}): {% if matched %}✓ in journal{% else %}✗ not in journal{% endif %}
+{% endif %}
+{% endfor %}
+{% else %}
+- No selected quests to cross-reference.
+{% endif %}
+
+**Content Summary:**
+{% set totalDisplayed = 0 %}{% set totalCompleted = 0 %}{% set totalFailed = 0 %}
+{% set miscCount = 0 %}{% set withJournalText = 0 %}
+{% for jq in journal %}
+{% if jq.isMisc %}{% set miscCount = miscCount + 1 %}{% endif %}
+{% if jq.journalText %}{% set withJournalText = withJournalText + 1 %}{% endif %}
+{% if jq.objectives and length(jq.objectives) > 0 %}
+{% for obj in jq.objectives %}
+{% if obj.displayed %}{% set totalDisplayed = totalDisplayed + 1 %}{% endif %}
+{% if obj.completed %}{% set totalCompleted = totalCompleted + 1 %}{% endif %}
+{% if obj.failed %}{% set totalFailed = totalFailed + 1 %}{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+- Misc quests: {{ miscCount }}
+- Quests with journal text: {{ withJournalText }}/{{ length(journal) }}
+- Displayed objectives: {{ totalDisplayed }}
+- Completed objectives: {{ totalCompleted }}
+- Failed objectives: {{ totalFailed }}
+
+**Specific Quest Lookups:**
+{% set hasMQ101 = false %}{% set hasMainQuest = false %}
+{% for jq in journal %}
+{% if jq.editorID == "MQ101" %}{% set hasMQ101 = true %}{% endif %}
+{% if jq.editorID == "MQ102" or jq.editorID == "MQ103" or jq.editorID == "MQ104" %}{% set hasMainQuest = true %}{% endif %}
+{% endfor %}
+- MQ101 in journal: {% if hasMQ101 %}✓ YES{% else %}✗ NO (not started or filtered){% endif %}
+- Main quest (MQ102/MQ103/MQ104) in journal: {% if hasMainQuest %}✓ YES{% else %}✗ NO{% endif %}
+
+**Default Call Idempotency:**
+{% set journalDefault = get_quest_journal() %}
+- Same result count: {% if length(journalDefault) == length(journal) %}✓ YES{% else %}✗ different{% endif %}
+
+{% for jq in journal %}
+{% if loop.index <= 3 %}
+**Quest {{ loop.index }} in list:** {{ jq.questName }} ({{ jq.editorID }})
+  - Stage {{ jq.stage }}, Misc={{ jq.isMisc }}, Log={{ jq.inQuestLog }}
+{% endif %}
+{% endfor %}
+
+{% else %}
+No journal entries found.
+{% endif %}
 
 ---
 


### PR DESCRIPTION
## Summary

Restores the quest journal prompt files to pair with the `get_quest_journal()` decorator fix in [MinLL/SkyrimNet#851](https://github.com/MinLL/SkyrimNet/pull/851).

## Changes

Reverts the temporary prompt-side workaround from #449 now that the DLL-side decorator fix is available:

**`submodules/character_bio/0610_party_quests.prompt`**
Restores the quest integration prompt that renders tracked quests with journal text and objectives. Uses `get_selected_quests()`, `get_quest_journal()`, and `get_intelengine_quests()`.

IntelEngine handling (lines 11-13) was added in PR #333 by Galanx — it special-cases the IntelEngine mod's quest entry because the raw entry shows as "IntelEngine (None): Investigate..." which provides useless context. The `get_intelengine_quests(npc.UUID)` decorator is registered via SkyrimNet's PublicAPI by IntelEngine itself, not part of base SkyrimNet. This block is preserved in this PR and can be removed separately if needed.

**`submodules/test_decorators/0600_quest_gamesystem_decorators.prompt`**
Restores Test 16 for `get_quest_journal()` — resolved journal data with objective text, cross-references with `get_selected_quests()`.

**`player_thoughts.prompt`**
Removes the temporary selected-quest prompt context added while `get_quest_journal()` was disabled.

**`components/character_bio_full.prompt`**
Removes the temporary active-quest integration block added while the quest journal submodule was disabled.

`submodules/test_decorators/0900_template_syntax_tests.prompt` and `warmup.prompt` already contain their expected `get_selected_quests()` calls and are unchanged.

## Context

The `get_quest_journal()` decorator was disabled in the DLL (PR #848) due to runtime crashes. Langfod's fix on `pr-850-test` (commit `33fec3e1`) resolves the issue by using the Quest cache for `BuildQuestJournalJson`. This PR restores the correct prompt-side files to match that fix.

## DLL Dependency

Depends on [MinLL/SkyrimNet#851](https://github.com/MinLL/SkyrimNet/pull/851) — the DLL fix must land first or concurrently for the decorator to produce results.
