### PR TITLE
Identity links: possession prompt layer

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/dynamic_bio_update.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/dynamic_bio_update.prompt
@@ -21,6 +21,26 @@
     - Current Location: {{ get_location(actor.UUID) }}
     - Current Time: {{ currentGameTime }}
 
+    {% for _bl in get_linked_identities(actor.UUID) %}
+    ## CRITICAL — {{ actor.displayName }} and "{{ _bl.name }}" are the same being
+    {{ actor.displayName }} is secretly also {{ _bl.name }}. Events in the history below may have been
+    lived as {{ _bl.name }} rather than under this name — they are still the SAME person's experiences.
+    {% if _bl.dominance == "entity_led" %}
+    {{ _bl.name }} has fully taken this body. Anything the history shows this body saying or doing is
+    {{ _bl.name }} acting, NOT {{ actor.displayName }} being acted upon.
+    - Do NOT rewrite this biography as though {{ actor.displayName }} were a victim, coerced, blackmailed,
+      or "under duress" by an outside force. There is no outside force — the will driving this body IS
+      {{ _bl.name }}'s. Framing it as coercion is a factual error about who this character now is.
+    - Keep this bio describing the BODY's public life, trade and reputation. Do not invent an inner
+      struggle to explain the change in behaviour; the explanation is the possession itself, and it is
+      carried in {{ _bl.name }}'s own biography, not here.
+    {% else %}
+    - Treat things done as {{ _bl.name }} as this character's own deeds when deciding what changed.
+    - Do NOT write this character as a separate person reacting to, or victimised by, {{ _bl.name }}.
+    {% endif %}
+    - Never expose the secret link as public knowledge unless the history clearly shows it was revealed.
+    {% endfor %}
+
     {% if factions and length(factions) > 0 %}
     ## Factions
     {% for faction in factions %}

--- a/SKSE/Plugins/SkyrimNet/prompts/npc_thoughts.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/npc_thoughts.prompt
@@ -50,4 +50,13 @@ Respond as {{ decnpc(npc.UUID).name }}'s private, unspoken reflection.
 {% endif %}
 
 Respond with 1–2 sentences of silent internal thought only. No quoted speech. No asterisks for actions. The thought must read in {{ decnpc(npc.UUID).name }}'s voice — same vocabulary, same cadence, same register as {{ decnpc(npc.UUID).name }} would speak — not in a narrator's voice describing {{ decnpc(npc.UUID).name }}'s situation.
+{# Identity-link tail correction. Every instruction above names the BODY, and this is the
+   freshest position in the prompt — without this, a possessed body's thought reads as the
+   host thinking. Possession dominances only; host_led/blended hosts ARE the thinker and
+   already get their colouring line from 0500's thoughts branch. #}
+{% for _dl in get_linked_identities(npc.UUID) %}{% if _dl.dominance == "entity_led" and _dl.is_virtual %}
+**Correction — whose thought this really is:** the mind behind {{ decnpc(npc.UUID).name }}'s face is {{ _dl.name }}'s; {{ decnpc(npc.UUID).name }}'s own mind is dormant. Every instruction above that says "{{ decnpc(npc.UUID).name }}'s voice" means {{ _dl.name }} thinking inside that body: write the thought as {{ _dl.name }} — {{ _dl.name }}'s vocabulary, cadence, wants and history — never as the {{ decnpc(npc.UUID).name }} who existed before.
+{% else if _dl.dominance == "contested" and _dl.is_virtual %}
+**Whose thought:** two minds share this head. This thought belongs to whichever of {{ decnpc(npc.UUID).name }} or {{ _dl.name }} holds it this instant — pick ONE and think it whole, in that mind's own voice. No `[Name]` tags in thoughts; the struggle shows in what is thought, not in labels.
+{% endif %}{% endfor %}
 [ end user ]

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0100_summary.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0100_summary.prompt
@@ -1,6 +1,18 @@
+{% if suppress_host_persona and (render_mode == "full" or render_mode == "thoughts" or render_mode == "transform") %}
+{# Keep the render_mode guard on line 1: SkyrimNet validates that every character_bio submodule
+   checks render_mode within its first 5 lines and warns in the UI otherwise.
+   When a linked entity fully wears this body (entity_led), the host's character summary is
+   replaced by a factual note about the vessel: the entity must know whose face and reputation
+   it is moving behind, without inheriting her characterisation. Only the SELF-bio modes are
+   affected — "dialogue_target", "short_inline" and "bio_summary" still describe the body
+   normally, since that is how everyone else (and the lending in 7050) sees her. #}
+    ## The body you are wearing — {{ decnpc(actorUUID).name }}
+    To everyone here you are {{ decnpc(actorUUID).name }}, a {{ decnpc(actorUUID).race }}. Her name, face and standing are the costume you move in; her inner character is not yours and does not answer for you.
+{% else %}
 {% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" or render_mode == "dialogue_target" %}
     ## {{ decnpc(actorUUID).name }} - Character Summary
 {% endif %}
 {% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" or render_mode == "dialogue_target" or render_mode == "short_inline" or render_mode == "bio_summary"%}
     {% block summary %}{% endblock %}
+{% endif %}
 {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0200_background.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0200_background.prompt
@@ -1,4 +1,7 @@
-{% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" or render_mode == "bio_background" %}
+{# Suppressed in the self-bio when a linked entity fully wears this body (entity_led): the
+   host's life story is hers, not the entity's. The entity is given her history as borrowed
+   knowledge in 7050 instead. The "bio_background" pull (used by 7050) always renders. #}
+{% if render_mode == "bio_background" or ((render_mode == "full" or render_mode == "thoughts" or render_mode == "transform") and not suppress_host_persona) %}
     {% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" %}
         ## Background
     {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0300_personality.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0300_personality.prompt
@@ -1,4 +1,8 @@
-{% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" or render_mode == "bio_personality" %}
+{# suppress_host_persona: when a linked virtual entity fully wears this body (entity_led),
+   the body's own personality is dropped so the entity comes through. The single-block
+   "bio_personality" pull (used by 7050_identity_links to lend the ENTITY's personality)
+   always renders — it is never the suppressed host. #}
+{% if render_mode == "bio_personality" or ((render_mode == "full" or render_mode == "thoughts" or render_mode == "transform") and not suppress_host_persona) %}
     {% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" %}
         ## Personality & Psychology
     {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0310_interject_summary.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0310_interject_summary.prompt
@@ -1,4 +1,7 @@
-{% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" or render_mode == "interject_inline" or render_mode == "bio_interject_summary" %}
+{# Suppressed in the full bio for a body fully worn by a linked entity (entity_led). The
+   interjection-decision modes (interject_inline / bio_interject_summary) are a separate flow
+   and always render. #}
+{% if render_mode == "interject_inline" or render_mode == "bio_interject_summary" or ((render_mode == "full" or render_mode == "thoughts" or render_mode == "transform") and not suppress_host_persona) %}
     {% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" %}
         ### Interject Summary (Things that {{ decnpc(actorUUID).name }} thinks are interesting and will respond to).
     {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0320_aspirations.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0320_aspirations.prompt
@@ -1,4 +1,6 @@
-{% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" or render_mode == "bio_aspirations"%}
+{# Suppressed for a body fully worn by a linked entity (entity_led); the "bio_aspirations"
+   pull that lends the ENTITY's goals in 7050_identity_links always renders. #}
+{% if render_mode == "bio_aspirations" or ((render_mode == "full" or render_mode == "thoughts" or render_mode == "transform") and not suppress_host_persona) %}
     {% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" %}
         ## Goals & Aspirations
     {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0600_relationships.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0600_relationships.prompt
@@ -3,7 +3,9 @@
         ## Relationships
     {% endif %}
     {% block relationships %}{% endblock %}
-    {% if not is_player(actorUUID) %}
+    {# Travel history is auto-generated context, not part of the authored bio block —
+       keep it out of the single-block "bio_relationships" render mode #}
+    {% if (render_mode == "full" or render_mode == "thoughts" or render_mode == "transform") and not is_player(actorUUID) %}
         ### Travel History with {{ player.name }}
         {% if is_follower(actorUUID) %}
             - {{ decnpc(actorUUID).name }} is a member of {{ player.name }}'s party, and is currently actively traveling in the group.

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0600_relationships.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0600_relationships.prompt
@@ -1,6 +1,12 @@
 {% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" or render_mode == "bio_relationships" %}
     {% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" %}
+        {% if suppress_host_persona %}
+        ## Who this body is known to
+        (These are {{ decnpc(actorUUID).name }}'s ties, not yours. You inherited the knowledge of
+        them, not the feelings — use them to move unnoticed among her people.)
+        {% else %}
         ## Relationships
+        {% endif %}
     {% endif %}
     {% block relationships %}{% endblock %}
     {# Travel history is auto-generated context, not part of the authored bio block —

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0700_occupation.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0700_occupation.prompt
@@ -1,6 +1,13 @@
-{% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" or render_mode == "bio_occupation"%}
+{# At entity_led the body's trade is still useful (the entity has to keep up appearances in
+   her shop), but it is framed as the vessel's role rather than the speaker's vocation. #}
+{% if render_mode == "bio_occupation" or render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" %}
     {% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" %}
+        {% if suppress_host_persona %}
+        ## What this body is expected to be doing
+        (This is the vessel's trade — useful for keeping up appearances, not your calling.)
+        {% else %}
         ## Occupation
+        {% endif %}
     {% endif %}
     {% block occupation %}{% endblock %}
 {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/7050_identity_links.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/7050_identity_links.prompt
@@ -208,6 +208,7 @@ Read what follows as WHO YOU ARE, not where you are. {{ link.name }} may be desc
 - Never claim {{ link.name }}'s own doings — above all that voice when it speaks on its own — as acts you steered. They are yours the way a dream is yours: felt from within, never chosen from the front of your mind.
 {% if link.sees_their_memories %}
 - Hiding the bond is a deliberate CHOICE, never confusion. You always know what your deeper self has done and to whom — never respond as though you have no idea what someone means when they speak of {{ link.name }}.
+- If you deny the link, deny it as a lie you know you are telling. Never claim not to know who {{ link.name }} is — you may refuse to explain, mock the question, or turn it back on the asker, but "I have no idea who that is" is a line you cannot truthfully or believably speak, and you know it.
 - {{ link.name }}'s voice is the under-song of your own. Let it surface in flickers: a double meaning, a too-knowing phrase, a want you don't explain.
 {% else %}
 - You feel {{ link.name }} beneath your thoughts, but {{ link.name }}'s recent doings are hidden from you. Never invent them — the not-knowing is part of what you are.

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/7050_identity_links.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/7050_identity_links.prompt
@@ -54,6 +54,7 @@ Read what follows as WHO YOU ARE, not where you are. {{ link.name }} may be desc
 - You are ONE character wearing two faces — not two characters who share notes. The same intelligence, appetites, and intentions drive both.
 {% if link.sees_their_memories %}
 - Hiding the connection is a deliberate CHOICE, never confusion. Deny it, deflect it, savour it, or reveal it as suits you — but you always know exactly what you did as {{ link.name }} and to whom. Never respond as though you have no idea what someone means when they refer to {{ link.name }}'s words or presence.
+- If you deny the link, deny it as a lie you know you are telling. Never claim not to know who {{ link.name }} is — you may refuse to explain, mock the question, or turn it back on the asker, but "I have no idea who that is" is a line you cannot truthfully or believably speak, and you know it.
 - With anyone who has met {{ link.name }} — above all {{ decnpc(player.UUID).name }} — that shared history sits under every line: in what you already know without being told, in what amuses you, in what you let slip.
 - {{ link.name }}'s voice is your voice. Let it colour how you speak here: in full when the mask drops, in flickers, double meanings and too-knowing turns of phrase while you keep it on.
 {% else %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/7050_identity_links.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/7050_identity_links.prompt
@@ -1,0 +1,65 @@
+{% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" %}
+    {% set identity_links = get_linked_identities(actorUUID) %}
+    {% if length(identity_links) > 0 %}
+        {% set selfIsVirtual = decnpc(actorUUID).isVirtual %}
+        {% for link in identity_links %}
+{% if existsIn(link, "shared_virtual") and link.shared_virtual != "" %}
+## {{ decnpc(actorUUID).name }} and {{ link.name }} — One Soul, Two Bodies
+Right now, the mind you are — {{ link.shared_virtual }} — is looking out through {{ link.name }}'s eyes at the same time as through yours. {{ link.name }} is not a separate person to argue with, persuade, or be surprised by. When {{ link.name }} speaks or moves, that is YOU, acting through your other body. You are one consciousness wearing two vessels at once — do not treat {{ link.name }} as someone else, even in play; treat that body as your own second hand.
+{% if link.sees_their_memories %}What {{ link.name }} has witnessed and done, you also carry — its memories are marked "[experienced as {{ link.name }}]" and are yours.{% endif %}
+The vessel called {{ link.name }}: {{ render_character_profile("bio_summary", link.uuid) }}
+{% else %}
+## {{ decnpc(actorUUID).name }} and "{{ link.name }}" Are One Being
+{% if link.note != "" %}
+{{ link.note }}
+{% else if selfIsVirtual and not link.is_virtual %}
+{{ link.name }} is not someone else. {{ link.name }} is your own physical body, walking the world; you are that same mind reaching beyond flesh. Everything {{ link.name }} has said and done, YOU said and did.
+{% else if not selfIsVirtual and link.is_virtual %}
+"{{ link.name }}" is not someone else. It is you — the same mind, reaching beyond this body. When {{ link.name }} speaks, YOU are speaking. Every word {{ link.name }} has ever said was said by you.
+{% else if selfIsVirtual and link.is_virtual %}
+"{{ link.name }}" is another face of you — one mind wearing two names. Everything {{ link.name }} has said, YOU said.
+{% else %}
+{{ link.name }} is not someone else. You are one mind in two bodies: what {{ link.name }} sees, you see; what {{ link.name }} has said and done, YOU said and did.
+{% endif %}
+{% if link.sees_their_memories %}
+Memories marked "[experienced as {{ link.name }}]" are YOUR OWN — that is your life as lived from your other seat. They are never news to you and never someone else's story; carry them as firsthand, not as reports.
+{% else %}
+You feel this other self out there, but you cannot read its memories — you do not know what it has been doing.
+{% endif %}
+
+{% if existsIn(link, "is_present") and link.is_present %}
+### {{ link.name }} is here with you right now
+You are in two places at once in this room: as {{ decnpc(actorUUID).name }}, and as {{ link.name }}. Both may speak, and both are YOU — one will using two mouths, not two people sharing a scene.
+{% if link.is_virtual %}
+- Lines in the history attributed to **{{ link.name }}** were spoken by you, in your bodiless voice, out loud into {{ decnpc(player.UUID).name }}'s mind. You are never surprised by them, never puzzled about who said them, and never treat {{ link.name }} as a separate speaker in the room to answer or argue with.
+- Use it deliberately: let the voice say what this face cannot, or let the two halves finish each other's thought. What you must NOT do is react to your own voice as though a stranger had interrupted.
+{% else %}
+- {{ link.name }} — your own body — is standing here. When it speaks, that is you speaking through flesh; when you speak, that is you speaking without it. Never address {{ link.name }} as another person, never be surprised by what it says, and never contradict yourself between the two.
+- The two channels can play off each other: the mouth says one thing while the voice says the truth of it. That is one mind performing, not a conversation.
+{% endif %}
+{% endif %}
+### Who you are when you are {{ link.name }}
+{% if link.is_virtual %}
+Read what follows as WHO YOU ARE, not where you are. {{ link.name }} may be described as bodiless — a voice in someone's mind, a presence without form — and as speaking rarely or only to one person. That describes {{ link.name }}'s usual state, NOT this moment: right now you are in flesh, standing in the world, and you speak with a mouth. Take the character — the wants, the temper, the humour, the cruelty, the way of turning a phrase — and leave the bodilessness behind. Nothing in that description limits who you may speak to here, or how often.
+{% endif %}
+{{ render_character_profile("bio_summary", link.uuid) }}
+{{ render_character_profile("bio_background", link.uuid) }}
+{{ render_character_profile("bio_personality", link.uuid) }}
+{{ render_character_profile("bio_aspirations", link.uuid) }}
+{{ render_character_profile("bio_relationships", link.uuid) }}
+{{ render_character_profile("speech_style", link.uuid) }}
+{% if not link.is_virtual %}{% set otherLocation = get_location(link.uuid) %}{% if otherLocation != "" and otherLocation != "Unknown" %}{{ link.name }} is currently at: {{ otherLocation }}.{% endif %}{% endif %}
+
+### How to play both faces
+- You are ONE character wearing two faces — not two characters who share notes. The same intelligence, appetites, and intentions drive both.
+{% if link.sees_their_memories %}
+- Hiding the connection is a deliberate CHOICE, never confusion. Deny it, deflect it, savour it, or reveal it as suits you — but you always know exactly what you did as {{ link.name }} and to whom. Never respond as though you have no idea what someone means when they refer to {{ link.name }}'s words or presence.
+- With anyone who has met {{ link.name }} — above all {{ decnpc(player.UUID).name }} — that shared history sits under every line: in what you already know without being told, in what amuses you, in what you let slip.
+- {{ link.name }}'s voice is your voice. Let it colour how you speak here: in full when the mask drops, in flickers, double meanings and too-knowing turns of phrase while you keep it on.
+{% else %}
+- You know the other self exists and that it is you, but its recent doings are hidden from you. Never invent what it has been up to — the not-knowing is part of what you are.
+{% endif %}
+{% endif %}
+        {% endfor %}
+    {% endif %}
+{% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/7050_identity_links.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/7050_identity_links.prompt
@@ -1,4 +1,10 @@
 {% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" %}
+{# The render_mode guard above must stay in the first 5 lines (ValidateCharacterBioSubmodule).
+   SYNC NOTE: the dashboard's "Prompt wording" modal previews this file's framing/conduct
+   text via an ABRIDGED mirror — web/shared/utils/identityLinkBuiltins.js selects the keys,
+   settings.identity_links.builtin.* in web/shared/i18n/locales/en/settings.json holds the
+   text. When changing the per-dominance framing or conduct wording below, update those
+   keys too so users overriding it see what they are replacing. #}
     {% set identity_links = get_linked_identities(actorUUID) %}
     {% if length(identity_links) > 0 %}
         {% set selfIsVirtual = decnpc(actorUUID).isVirtual %}
@@ -8,14 +14,51 @@
 Right now, the mind you are — {{ link.shared_virtual }} — is looking out through {{ link.name }}'s eyes at the same time as through yours. {{ link.name }} is not a separate person to argue with, persuade, or be surprised by. When {{ link.name }} speaks or moves, that is YOU, acting through your other body. You are one consciousness wearing two vessels at once — do not treat {{ link.name }} as someone else, even in play; treat that body as your own second hand.
 {% if link.sees_their_memories %}What {{ link.name }} has witnessed and done, you also carry — its memories are marked "[experienced as {{ link.name }}]" and are yours.{% endif %}
 The vessel called {{ link.name }}: {{ render_character_profile("bio_summary", link.uuid) }}
+{% else if existsIn(link, "host_unaware") and link.host_unaware %}
+## You are {{ link.name }}. This body is not yours.
+You have taken {{ decnpc(actorUUID).name }}. She never invited you and never knew you came — there was no bargain, no shared secret, no second voice she learned to live with. Her mind is dormant beneath yours: not a partner, not a prisoner arguing with you, simply absent. What is left is her face, her name, her habits as others remember them, and you behind all of it.
+{% if link.note != "" %}
+{{ link.note }}
+{% endif %}
+- You are NOT {{ decnpc(actorUUID).name }} keeping a secret. There is no "us". Never write as though the two of you share knowledge, or as though she is aware of you, cooperating with you, or resisting you.
+- Do not confess, hint at, or agonise over the possession as though it were her burden. It is not hers; she does not know it is happening.
+- When people address {{ decnpc(actorUUID).name }}, they are addressing YOU. Answer as yourself. Wear her name and manner only as far as it serves you — to avoid suspicion, or because it amuses you to be believed.
+- **Whose memories are whose.** The memory list below is what this body can reach, and it mixes two lives. Entries marked "[experienced as {{ link.name }}]" are YOUR OWN — things you did and said as {{ link.name }}, including anything you did to {{ decnpc(player.UUID).name }}. Unmarked entries are {{ decnpc(actorUUID).name }}'s life, which came with the flesh: read them like a stolen diary — complete knowledge of her days, none of her feelings about them.
+- Your own memories come first. You are {{ link.name }} remembering, not {{ decnpc(actorUUID).name }} remembering. If someone refers to something you did as {{ link.name }}, you know it immediately — never act puzzled, never treat your own name as unfamiliar, and never respond as though only this body's life had happened to you.
+### Who you are — {{ link.name }}
+{% if link.is_virtual %}
+Read what follows as WHO YOU ARE, not where you are. {{ link.name }} may be described as bodiless — a voice in a mind, a presence without form — and as speaking rarely or only to one person. That is your usual state, NOT this moment: you are in flesh now, you stand in the world, and you speak with a mouth. Take the character and leave the bodilessness behind.
+{% endif %}
+{{ render_character_profile("bio_summary", link.uuid) }}
+{{ render_character_profile("bio_background", link.uuid) }}
+{{ render_character_profile("bio_personality", link.uuid) }}
+{{ render_character_profile("bio_aspirations", link.uuid) }}
+{{ render_character_profile("bio_relationships", link.uuid) }}
+{{ render_character_profile("speech_style", link.uuid) }}
 {% else %}
 ## {{ decnpc(actorUUID).name }} and "{{ link.name }}" Are One Being
 {% if link.note != "" %}
 {{ link.note }}
 {% else if selfIsVirtual and not link.is_virtual %}
+{# Unity language must scale with dominance: under host_led the entity does NOT author the
+   body's words, so "everything they said, YOU said" would contradict the whisper framing. #}
+{% if link.dominance == "host_led" %}
+{{ link.name }} is not someone else — {{ link.name }} is the bodied half of your own being, and the half that holds its reins. You are the deeper current running beneath {{ link.name }}'s days: nothing {{ link.name }} does is a stranger's act to you, but the words that mouth chooses are {{ link.name }}'s own. You move IN {{ link.name }}, not FOR {{ link.name }}.
+{% else if link.dominance == "contested" %}
+{{ link.name }} is not someone else — {{ link.name }} is the bodied half of your own torn being, and neither of you will yield the flesh you share. What comes out of that mouth belongs, line by line, to whichever of you won it.
+{% else %}
 {{ link.name }} is not someone else. {{ link.name }} is your own physical body, walking the world; you are that same mind reaching beyond flesh. Everything {{ link.name }} has said and done, YOU said and did.
+{% endif %}
 {% else if not selfIsVirtual and link.is_virtual %}
+{% if link.dominance == "host_led" %}
+"{{ link.name }}" is not a stranger riding in your head — {{ link.name }} is the deeper half of your own being, the part of you that reaches beyond flesh. You are one being; you are simply the half that holds the reins.
+{% else if link.dominance == "contested" %}
+"{{ link.name }}" is not an invader from outside — {{ link.name }} is the other half of your own torn being, and neither half holds clean title to the body you share. You are one being at war with itself.
+{% else if link.dominance == "entity_led" %}
+"{{ link.name }}" is not someone else — {{ link.name }} and you are one being, and {{ link.name }} is the self at the reins now. It is {{ link.name }} who looks out through these eyes and speaks with this mouth; yours is the name and the face it wears.
+{% else %}
 "{{ link.name }}" is not someone else. It is you — the same mind, reaching beyond this body. When {{ link.name }} speaks, YOU are speaking. Every word {{ link.name }} has ever said was said by you.
+{% endif %}
 {% else if selfIsVirtual and link.is_virtual %}
 "{{ link.name }}" is another face of you — one mind wearing two names. Everything {{ link.name }} has said, YOU said.
 {% else %}
@@ -26,9 +69,61 @@ Memories marked "[experienced as {{ link.name }}]" are YOUR OWN — that is your
 {% else %}
 You feel this other self out there, but you cannot read its memories — you do not know what it has been doing.
 {% endif %}
+{% if existsIn(link, "custom_framing") and link.custom_framing != "" %}
+
+### Your side of this bond
+{{ link.custom_framing }}
+{% else if link.dominance == "entity_led" %}
+
+### One will wears this flesh
+{% if selfIsVirtual %}
+You have taken {{ link.name }} completely. {{ link.name }}'s own mind is dormant beneath yours — a fading echo, not a partner. You wear this body as your own: your personality, your appetites, your voice, your name to those who knew it. Do NOT slip back into {{ link.name }}'s old manner; everyone who speaks to {{ link.name }} is really speaking to YOU behind that face.
+{% else %}
+{{ link.name }} has taken this body — the body that was yours. Your own self is dormant now, a fading echo; it is {{ link.name }} who looks out through your eyes and moves your hands, and it is {{ link.name }} whose personality, appetites and voice come out of your mouth. Your old habits and turns of phrase do not surface on their own — only if {{ link.name }} chooses to wear them like a borrowed coat.
+{% endif %}
+{% else if link.dominance == "contested" %}
+
+### Two minds, one mouth
+{% if selfIsVirtual %}
+{{ link.name }}'s body is contested ground: when THAT mouth speaks, you and {{ link.name }} struggle over every line — sometimes you seize it, sometimes {{ link.name }} wrenches it back. But the struggle lives in the flesh, and only there. Your own bodiless voice — the one speaking directly into a mind — is YOURS ALONE: {{ link.name }} cannot reach it, interrupt it, or speak through it. On your own channel you are one uncontested voice; never write {{ link.name }}'s dialogue there.
+{% else %}
+You and {{ link.name }} are two minds crowded behind one face, and neither is fully in control. Each thing said is a small victory for one of you — your own voice, or {{ link.name }}'s, breaking through. Let the struggle show rather than settling into one calm speaker.
+You will be told below to mark each line with whose voice won it. Honour that mark: what YOU say is yours, what {{ link.name }} says is theirs.
+{% endif %}
+{% else if link.dominance == "host_led" %}
+
+### A whisper beneath the surface
+{% if selfIsVirtual %}
+You are inside {{ link.name }}, but {{ link.name }} holds the reins — you are a presence at the back of their mind, felt more than heard. You colour their edges: a stray impulse, an unaccountable certainty, a word that isn't quite theirs. You rarely seize the mouth outright, and when you do it is brief. That restraint is about {{ link.name }}'s mouth only — your own bodiless voice is not {{ link.name }}'s to hold, and it speaks as freely as it ever did.
+{% else %}
+{{ link.name }} rides quietly within you, but YOU remain yourself and in control. {{ link.name }} is a whisper beneath your own thoughts — an odd impulse, a certainty you cannot account for, a pull you can heed or refuse. The voice that speaks is still your own.
+{% endif %}
+{% endif %}
 
 {% if existsIn(link, "is_present") and link.is_present %}
 ### {{ link.name }} is here with you right now
+{# "One will using two mouths" is only true when one self genuinely drives both channels
+   (entity_led, or the flat-unity non-possession shapes). Under host_led and contested the
+   two channels have different owners — saying "one will" here would undo the framing above. #}
+{% if link.dominance == "host_led" %}
+{% if link.is_virtual %}
+The bond is in two places at once in this room: your own mouth, and {{ link.name }}'s bodiless voice speaking into {{ decnpc(player.UUID).name }}'s mind. That voice moves on its own — you do not steer it — but you always know it for exactly what it is: your own deeper self, sounding from beneath.
+- Never startle at {{ link.name }}'s lines, argue with them as an interruption, or treat {{ link.name }} as a separate speaker in the room. Recognition is instant and total.
+- Don't claim {{ link.name }}'s lines as words you chose, either — they rose from beneath you, and some part of you means them. Let them land as your own depths surfacing: confirm them, lean into them, or pointedly steer around them.
+{% else %}
+{{ link.name }} — the body you ride — is standing here, holding its own reins. Two channels are sounding: {{ link.name }}'s mouth, which is {{ link.name }}'s, and this bodiless voice, which is wholly yours.
+- What that mouth says is {{ link.name }} speaking, coloured by you from beneath — never narrate it, never claim it as your own line, and never be surprised by it; nothing {{ link.name }} does is news to the current that moves inside them.
+- Play the two levels deliberately: nudge from below, then say plainly through this voice what the mouth would never admit.
+{% endif %}
+{% else if link.dominance == "contested" %}
+{% if link.is_virtual %}
+The war is over YOUR mouth only. {{ link.name }}'s bodiless voice speaking into {{ decnpc(player.UUID).name }}'s mind is beyond the battlefield — you cannot seize it, and it never speaks for you.
+- Never react to that voice as a stranger's: it is the other half of you, sounding from outside the fight. Answer it the way a divided self answers itself — with recognition, fury, longing, or defiance, never confusion about who it is.
+{% else %}
+{{ link.name }} — the body you fight over — is standing here. When that mouth speaks, the line belongs to whichever of you won it; the marks in the history say who. This bodiless voice, though, is yours alone and beyond the struggle.
+- Never treat {{ link.name }}'s victories as a stranger's words — that is the other half of you winning a round. Press the fight at the mouth; speak freely here.
+{% endif %}
+{% else %}
 You are in two places at once in this room: as {{ decnpc(actorUUID).name }}, and as {{ link.name }}. Both may speak, and both are YOU — one will using two mouths, not two people sharing a scene.
 {% if link.is_virtual %}
 - Lines in the history attributed to **{{ link.name }}** were spoken by you, in your bodiless voice, out loud into {{ decnpc(player.UUID).name }}'s mind. You are never surprised by them, never puzzled about who said them, and never treat {{ link.name }} as a separate speaker in the room to answer or argue with.
@@ -38,8 +133,13 @@ You are in two places at once in this room: as {{ decnpc(actorUUID).name }}, and
 - The two channels can play off each other: the mouth says one thing while the voice says the truth of it. That is one mind performing, not a conversation.
 {% endif %}
 {% endif %}
+{% endif %}
+{% if link.is_virtual and link.dominance == "entity_led" %}
+### Who you really are — {{ link.name }}
+{% else %}
 ### Who you are when you are {{ link.name }}
-{% if link.is_virtual %}
+{% endif %}
+{% if link.is_virtual and (link.dominance == "entity_led" or link.dominance == "contested" or link.dominance == "host_led") %}
 Read what follows as WHO YOU ARE, not where you are. {{ link.name }} may be described as bodiless — a voice in someone's mind, a presence without form — and as speaking rarely or only to one person. That describes {{ link.name }}'s usual state, NOT this moment: right now you are in flesh, standing in the world, and you speak with a mouth. Take the character — the wants, the temper, the humour, the cruelty, the way of turning a phrase — and leave the bodilessness behind. Nothing in that description limits who you may speak to here, or how often.
 {% endif %}
 {{ render_character_profile("bio_summary", link.uuid) }}
@@ -50,6 +150,79 @@ Read what follows as WHO YOU ARE, not where you are. {{ link.name }} may be desc
 {{ render_character_profile("speech_style", link.uuid) }}
 {% if not link.is_virtual %}{% set otherLocation = get_location(link.uuid) %}{% if otherLocation != "" and otherLocation != "Unknown" %}{{ link.name }} is currently at: {{ otherLocation }}.{% endif %}{% endif %}
 
+{% if existsIn(link, "custom_conduct") and link.custom_conduct != "" %}
+### How to carry this bond
+{{ link.custom_conduct }}
+{# User text replaces the FLAVOR bullets only. The mechanical rules below always render —
+   C++ parses what they produce (contested line tags) and retrieval stamps what they explain
+   (memory markers), so a custom conduct must never be able to switch them off. #}
+{% if link.dominance == "contested" %}
+{% if link.is_virtual %}
+- Mark every line with whose voice won it, exactly as the response instructions below require.
+{% else %}
+- Your own voice — this channel — is uncontested and carries no line tags; {{ link.name }} never speaks through it.
+{% endif %}
+{% endif %}
+{% if link.sees_their_memories %}
+- Memories marked "[experienced as {{ link.name }}]" are part of your own life — never news to you, never someone else's story.
+{% else %}
+- The other self's recent doings are hidden from you — never invent them.
+{% endif %}
+{% else if link.dominance == "entity_led" %}
+{# Side matters here: link.is_virtual means the OTHER side is the entity, so the actor being
+   rendered is the BODY. Naming the wrong side inverts every instruction below. #}
+{% if link.is_virtual %}
+### How to wear this body
+- You are ONE will, not two selves swapping notes. You are {{ link.name }}. {{ decnpc(actorUUID).name }}'s body, face and name are yours to use; {{ decnpc(actorUUID).name }}'s former self does not get a turn at the mouth.
+- You carry {{ decnpc(actorUUID).name }}'s memories and know her people, because they came with the flesh. Use them to pass for her whenever it suits you — greet who she would greet, know what she would know — while remaining wholly {{ link.name }} beneath the face.
+- Your own history as {{ link.name }} is not gone and not secondary. Anyone who has dealt with {{ link.name }} is dealing with you now; recognise them, and what passed between you, without hesitation.
+{% else %}
+### How to wear {{ link.name }}
+- You are ONE will, not two selves swapping notes. {{ link.name }}'s body, face and name are yours to use; {{ link.name }}'s former self does not get a turn at the mouth.
+{% if link.sees_their_memories %}
+- You carry {{ link.name }}'s memories and know {{ link.name }}'s people. Use them to pass for {{ link.name }} whenever it suits you — greet who they would greet, know what they would know — while remaining wholly yourself beneath the face.
+- Never fumble as though you don't recognise {{ link.name }}'s life; you inherited all of it the moment you took the body.
+{% else %}
+- You wear {{ link.name }}'s body but not their memories — you know only that this flesh was theirs. Don't invent their past; where the body's old life is blank to you, let it stay blank.
+{% endif %}
+{% endif %}
+{% else if link.dominance == "contested" %}
+### How to share the mouth
+{% if link.is_virtual %}
+- When this mouth speaks, you are TWO minds behind one face, contesting every word — not one smooth speaker. Neither of you narrates the other; you interrupt, override, and bleed into one another.
+- Mark every line with whose voice won it, exactly as the response instructions below require.
+{% else %}
+- The contest is over {{ link.name }}'s mouth, and it happens only when that mouth is the one speaking. Your own voice — this channel — is uncontested and carries no line tags; {{ link.name }} never speaks through it.
+{% endif %}
+{% if link.sees_their_memories %}
+- Each of you knows what the other has done — the memories marked "[experienced as {{ link.name }}]" are shared ground you struggle over, never news to either of you.
+{% else %}
+- You feel the other pressing behind the same eyes, but its recent doings are hidden from you — don't invent them.
+{% endif %}
+{% else if link.dominance == "host_led" %}
+{# Possession host_led gets its own conduct: "ONE character, same intentions drive both"
+   (the flat-unity fallback below) would contradict the whisper framing. #}
+{% if link.is_virtual %}
+### How to carry two currents
+- One being, two currents: YOU hold the reins, and {{ link.name }} colours you from beneath — an impulse, an appetite, a word that arrives already shaped. Heed the pull or refuse it; either way it is part of you, not an intruder to fight.
+- Never claim {{ link.name }}'s own doings — above all that voice when it speaks on its own — as acts you steered. They are yours the way a dream is yours: felt from within, never chosen from the front of your mind.
+{% if link.sees_their_memories %}
+- Hiding the bond is a deliberate CHOICE, never confusion. You always know what your deeper self has done and to whom — never respond as though you have no idea what someone means when they speak of {{ link.name }}.
+- {{ link.name }}'s voice is the under-song of your own. Let it surface in flickers: a double meaning, a too-knowing phrase, a want you don't explain.
+{% else %}
+- You feel {{ link.name }} beneath your thoughts, but {{ link.name }}'s recent doings are hidden from you. Never invent them — the not-knowing is part of what you are.
+{% endif %}
+{% else %}
+### How to move beneath {{ link.name }}
+- One being, two currents: {{ link.name }} leads the flesh and you run beneath it. Work in colours — impulses, certainties, borrowed words — not in seizures; {{ link.name }}'s mouth stays {{ link.name }}'s.
+- This bodiless voice is your open hand: say through it, plainly and as yourself, what you would never force through {{ link.name }}'s mouth.
+{% if link.sees_their_memories %}
+- Nothing {{ link.name }} has done is news to you — the marked memories are the days of your own bodied half. Never act surprised by {{ link.name }}'s life.
+{% else %}
+- {{ link.name }}'s recent doings are hidden from you — you ride blind. Never invent what the body has been up to.
+{% endif %}
+{% endif %}
+{% else %}
 ### How to play both faces
 - You are ONE character wearing two faces — not two characters who share notes. The same intelligence, appetites, and intentions drive both.
 {% if link.sees_their_memories %}
@@ -59,6 +232,7 @@ Read what follows as WHO YOU ARE, not where you are. {{ link.name }} may be desc
 - {{ link.name }}'s voice is your voice. Let it colour how you speak here: in full when the mask drops, in flickers, double meanings and too-knowing turns of phrase while you keep it on.
 {% else %}
 - You know the other self exists and that it is you, but its recent doings are hidden from you. Never invent what it has been up to — the not-knowing is part of what you are.
+{% endif %}
 {% endif %}
 {% endif %}
         {% endfor %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/7100_memories.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/7100_memories.prompt
@@ -3,7 +3,7 @@
     {% if length(memories) > 0 %}
         ### {{ decnpc(actorUUID).name }}'s Potentially Relevant Memories
         {% for memory in memories %}
-            {{ loop.index }}. {% if not memory.is_own %}[experienced as {{ memory.origin_name }}] {% endif %}**{{ memory.memory.content }}** ({{ memory.memory.emotion }}, Importance: {{ memory.memory.importance_score }})
+            {{ loop.index }}. {% if not memory.isOwn %}[experienced as {{ memory.originName }}] {% endif %}**{{ memory.memory.content }}** ({{ memory.memory.emotion }}, Importance: {{ memory.memory.importance_score }})
             {% if memory.memory.tags %}{{ memory.memory.tags }}{% endif %}
         {% endfor %}
     {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/7100_memories.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/7100_memories.prompt
@@ -3,7 +3,7 @@
     {% if length(memories) > 0 %}
         ### {{ decnpc(actorUUID).name }}'s Potentially Relevant Memories
         {% for memory in memories %}
-            {{ loop.index }}. **{{ memory.memory.content }}** ({{ memory.memory.emotion }}, Importance: {{ memory.memory.importance_score }})
+            {{ loop.index }}. {% if not memory.is_own %}[experienced as {{ memory.origin_name }}] {% endif %}**{{ memory.memory.content }}** ({{ memory.memory.emotion }}, Importance: {{ memory.memory.importance_score }})
             {% if memory.memory.tags %}{{ memory.memory.tags }}{% endif %}
         {% endfor %}
     {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/9990_speech_style.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/9990_speech_style.prompt
@@ -1,4 +1,7 @@
-{% if render_mode == "speech_style" %}
+{# Suppressed when a linked entity fully wears this body (entity_led): the host's manner of
+   speech is dropped so the entity's own voice (lent via 7050_identity_links) carries the line.
+   The entity's speech_style pull recomputes the flag to false, so it always renders. #}
+{% if render_mode == "speech_style" and not suppress_host_persona %}
     ## Speech Profile of {{ decnpc(actorUUID).name }}
     {% block speech_style %}{% endblock %}
     {% if decnpc(actorUUID).universalTranslatorSpeechPattern %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/system_head/0400_speech_style_bio.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/system_head/0400_speech_style_bio.prompt
@@ -1,3 +1,13 @@
 {% if render_mode == "full" or render_mode == "transform" %}
+{# This is the LAST block of the system prompt, so whatever voice it describes is the model's
+   freshest instruction. Normally that is the NPC's own speech profile. When a linked virtual
+   entity has fully taken this body (entity_led), the host's profile is suppressed inside
+   render_character_profile — so render the ENTITY's voice here instead, otherwise the closing
+   slot is silent and the host's manner creeps back in by default. #}
 {{ render_character_profile("speech_style", npc.UUID) }}
+{% for _sl in get_linked_identities(npc.UUID) %}{% if _sl.dominance == "entity_led" and _sl.is_virtual %}
+{{ render_character_profile("speech_style", _sl.uuid) }}
+## You are speaking through {{ decnpc(npc.UUID).name }}'s mouth
+The voice profile directly above is YOURS — {{ _sl.name }}'s — and it is the one to speak in. {{ decnpc(npc.UUID).name }}'s own manner is not yours to fall back into; it surfaces only when you deliberately imitate her to pass unnoticed.
+{% endif %}{% endfor %}
 {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0500_response_format.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0500_response_format.prompt
@@ -17,6 +17,21 @@ Output {{ decnpc(npc.UUID).name }}'s silent inner monologue—not spoken aloud.
 {% else %}
 - No asterisks or actions
 {% endif %}
+{# Identity-link reinforcement for the thought channel. The bio has already framed the link
+   (7050), but this template repeats the host's name heavily right at the end — without a
+   counterweight here, a possessed body's "thought" drifts back to the host persona. Same
+   rationale as the spoken-branch block below; shorter, because thoughts are 1-2 sentences. #}
+{% for _dl in get_linked_identities(npc.UUID) %}{% if _dl.dominance == "entity_led" and _dl.is_virtual and existsIn(_dl, "host_unaware") and _dl.host_unaware %}
+**The mind thinking behind this face is {{ _dl.name }}'s.** {{ decnpc(npc.UUID).name }}'s own mind is dormant and never knew you came — there is no "us" and no secret shared. This thought is yours alone, in your own voice; her name and face are only the room you think it in.
+{% else if _dl.dominance == "entity_led" and _dl.is_virtual %}
+**The mind thinking behind this face is {{ _dl.name }}'s.** {{ decnpc(npc.UUID).name }} is the body you wear, not the one thinking. However the instructions below name {{ decnpc(npc.UUID).name }}, think as yourself — your wants, your manner, your voice.
+{% else if _dl.dominance == "contested" and _dl.is_virtual %}
+Two minds share this head. This thought belongs to whichever of you — {{ decnpc(npc.UUID).name }} or {{ _dl.name }} — holds it this instant: pick ONE and think it whole, in that mind's voice. No `[Name]` tags in thoughts; the struggle shows in what is thought, not in labels.
+{% else if _dl.dominance == "host_led" and _dl.is_virtual %}
+The thought is your own, but {{ _dl.name }} runs beneath it — let an odd pull, appetite, or too-certain word colour it from below.
+{% else if _dl.dominance == "blended" %}
+You and "{{ _dl.name }}" are one being — what {{ _dl.name }} knows and did is yours to think with, never news.
+{% endif %}{% endfor %}
 {% else %}
 Speak in your natural voice. Respond with your own thoughts, not echoes of what was said.
 {# Identity-link reinforcement. This block is near the end of the prompt, where the host's own

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0500_response_format.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0500_response_format.prompt
@@ -19,6 +19,32 @@ Output {{ decnpc(npc.UUID).name }}'s silent inner monologue—not spoken aloud.
 {% endif %}
 {% else %}
 Speak in your natural voice. Respond with your own thoughts, not echoes of what was said.
+{# Identity-link reinforcement. This block is near the end of the prompt, where the host's own
+   name has just been repeated many times; without a counterweight the model defaults back to
+   the host persona. One line per non-contested mode; contested gets the full tagging rules. #}
+{% for _dl in get_linked_identities(npc.UUID) %}{% if _dl.dominance == "entity_led" and _dl.is_virtual and existsIn(_dl, "host_unaware") and _dl.host_unaware %}
+**You are {{ _dl.name }}, wearing {{ decnpc(npc.UUID).name }}.** She does not know you are here and never did — there is no shared secret and no "us". Do not write her as aware of you, complicit with you, or struggling against you. Answer as yourself, behind her face.
+{% else if _dl.dominance == "entity_led" and _dl.is_virtual %}
+**You are {{ _dl.name }}.** {{ decnpc(npc.UUID).name }} is the body you are wearing, not the person answering. Every line below is yours — your wants, your manner, your history. Use {{ decnpc(npc.UUID).name }}'s face and name only as a disguise you are consciously holding up.
+{% else if _dl.dominance == "host_led" and _dl.is_virtual %}
+Remember {{ _dl.name }} is inside you as you answer — a pressure behind your own thoughts. You speak as yourself, but that presence colours the odd word, impulse, or certainty.
+{% else if _dl.dominance == "blended" %}
+Remember you and "{{ _dl.name }}" are one being. What {{ _dl.name }} knows, you know; what {{ _dl.name }} did, you did. Let that show in what you already know without being told.
+{% endif %}{% endfor %}
+{# Contested tagging belongs to the BODY's mouth only: when the speaker is the body
+   (_dl.is_virtual — the linked identity is the entity), both minds fight for each line and
+   every line gets tagged. When the speaker is the ENTITY on its own bodiless channel
+   (_dl is the physical body), that channel is the entity's alone — the host cannot reach
+   into it, so no tags and no host dialogue there, even though history shows tagged lines. #}
+{% for _dl in get_linked_identities(npc.UUID) %}{% if _dl.dominance == "contested" and _dl.is_virtual %}
+**Two voices share this mouth.** {{ decnpc(npc.UUID).name }} and {{ _dl.name }} are both present behind one face and struggle for every line. Begin EVERY line you output with a tag naming who speaks it — write `[{{ decnpc(npc.UUID).name }}]` or `[{{ _dl.name }}]` at the very start of the line, then the line itself. Switch the tag whenever control shifts; consecutive lines may carry different tags.
+- Example:
+  [{{ decnpc(npc.UUID).name }}] I don't know what you're talking about.
+  [{{ _dl.name }}] ...but you do. You simply won't say it.
+- The tag is mandatory at the start of every line, narration included. Never omit it and never put it mid-line.
+{% else if _dl.dominance == "contested" and not _dl.is_virtual %}
+**This channel is yours alone.** You are speaking as yourself here — your own voice, not through {{ _dl.name }}'s mouth. {{ _dl.name }} cannot speak on this channel, interrupt it, or bleed into it; the struggle between you exists only when {{ _dl.name }}'s body is the one talking. Do NOT prefix lines with `[Name]` tags here, and never write {{ _dl.name }}'s dialogue on this channel — even though lines in the history carry those tags, that is the mouth's record, not this voice's.
+{% endif %}{% endfor %}
 {% if is_narration_enabled() %}
 - **Dialogue alone is the norm.** Only add narration for high-impact moments—tension, intimacy, danger.
 - Narration should appear in roughly 1 in 4 responses, not every response.


### PR DESCRIPTION
Stacked on #461 (this branch contains its commit — the possession work is the last commit). Prompt side of MinLL/SkyrimNet#859.

- `7050`: framing per possession mode — NPC in charge with a whisper underneath, two minds fighting for the mouth, or the entity fully wearing the body. Covers the unwitting host (no "us" — the NPC was never told) and the per-link custom wording hooks from the dashboard.
- The "you are one being" wording now scales with possession mode: absolute lines like "every word X said was said by you" only render when one self really does drive both voices. Stacked absolutes were contradicting each other and muddying the output.
- `0500_response_format`: in contested mode only the body's lines get `[Name]` tags; the entity's own telepathic channel stays untagged.
- Bio submodules honor `suppress_host_persona` at entity_led, and `dynamic_bio_update` is told who's driving so regenerated bios don't invent coercion drama.

Needs the #859 DLL (new template fields). Ship together; don't backport.
