### PR TITLE
feat: add SkyrimNet Bards sound category

### DIFF
--- a/plugins/SkyrimNet/SoundCategories/SkyrimNet_AudioCategoryBardSinging - 0012E3_SkyrimNet.esp.json
+++ b/plugins/SkyrimNet/SoundCategories/SkyrimNet_AudioCategoryBardSinging - 0012E3_SkyrimNet.esp.json
@@ -1,0 +1,14 @@
+{
+  "FormKey": "0012E3:SkyrimNet.esp",
+  "EditorID": "SkyrimNet_AudioCategoryBardSinging",
+  "Name": {
+    "TargetLanguage": "English",
+    "Value": "SkyrimNet Bards"
+  },
+  "Flags": [
+    "ShouldAppearOnMenu"
+  ],
+  "Parent": "0DDDC5:Skyrim.esm",
+  "StaticVolumeMultiplier": 0.5,
+  "DefaultMenuVolume": 1.0
+}


### PR DESCRIPTION
Attached as part of https://github.com/MinLL/SkyrimNet/pull/861

Adds a custom sound category for controlling bard singing audio when using the engine path. Essentially just adds a slider in Skyrim System > Settings > Audio > SkyrimNet Bards
---

New SNCT 0x0012E3, so bard singing has its own volume instead of riding the Voice slider that speech uses. Appears in Skyrim's Audio settings as "SkyrimNet Bards" via ShouldAppearOnMenu, parented to AudioCategoryPausedDuringMenu the same as $Voice.

StaticVolumeMultiplier 0.5 because singing at speech level is too loud, and DefaultMenuVolume 1.0 so that trim is applied once: the two fields multiply.

Required by SkyrimNet's engine audio path, which resolves this form by editor plugin name at runtime. If it is missing, songs play with no category at all and ignore any volume setting, logged as an error.