### PR TITLE
cleanup: fold book_read_manual into book_read (player_thoughts template + docs)

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/player_thoughts.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/player_thoughts.prompt
@@ -1,7 +1,7 @@
 [ system ]
 You are {{ decnpc(npc.UUID).name }}, a {{ decnpc(npc.UUID).gender }} {{ decnpc(npc.UUID).race }} in Skyrim.
 
-{% if triggeringEvent and (triggeringEvent.type == "book_read" or triggeringEvent.type == "book_read_manual") %}
+{% if triggeringEvent and triggeringEvent.type == "book_read" %}
 {{ render_subcomponent("system_head", "book") }}
 {% else %}
 {{ render_subcomponent("system_head", "thoughts") }}
@@ -66,17 +66,16 @@ Express a genuine {{ decnpc(npc.UUID).name }} thought on this topic:
 You are picking ONE of the listed lines above to say to {% if dialogueSpeaker and dialogueSpeaker.name and length(dialogueSpeaker.name) > 0 %}{{ dialogueSpeaker.name }}{% else %}the person in front of you{% endif %}. Your reasoning is the silent thought that justifies the pick — feel the moment, but stay focused on the choice.
 {% elif length(promptForThoughts) > 0 %}
 ## REMINDER: Your thought must be about "{{ promptForThoughts }}"
-{% elif is_in_combat(npc.UUID) %}
-## React to Combat
-Think about how this fight feels—the fear or fury, the pain, what drives survival.
-
-{% elif triggeringEvent and (triggeringEvent.type == "book_read" or triggeringEvent.type == "book_read_manual") %}
+{% elif triggeringEvent and triggeringEvent.type == "book_read" %}
 ## React to Reading
 {% if triggeringEvent.data %}
 {% set bookData = triggeringEvent.data %}
 You just finished "{{ bookData.book_title }}".
 {% if bookData.book_text and length(bookData.book_text) > 0 %}
-Contents: {{ bookData.book_text }}
+Contents:
+```
+{{ bookData.book_text }}
+```
 {% endif %}
 {% if bookData.book_vision_description and length(bookData.book_vision_description) > 0 %}
 
@@ -84,6 +83,10 @@ Visual details: {{ bookData.book_vision_description }}
 {% endif %}
 {% endif %}
 What does this mean to you? How does it relate to your situation?
+
+{% elif is_in_combat(npc.UUID) %}
+## React to Combat
+Think about how this fight feels—the fear or fury, the pain, what drives survival.
 
 {% elif triggeringEvent and triggeringEvent.type %}
 ## React to Event

--- a/docs/modding/WORKFLOW_TRIGGERS.md
+++ b/docs/modding/WORKFLOW_TRIGGERS.md
@@ -226,8 +226,7 @@ mcp_skyrimnet-mcp_validate_custom_trigger:
 | `activation` | Object/furniture use | `actor`, `target_name`, `activator_editor_id` |
 | `equip` | Equipment change | `actor`, `item`, `action`, `equipped` |
 | `sleep_start` / `sleep_stop` | Sleep events | `actor` |
-| `book_read` | Book reading | `book_name`, `book_title`, `book_text` |
-| `book_read_manual` | Capture Crosshair hotkey book event - emitted once after Book Menu closes for first accepted capture in session | `book_name`, `book_title`, `book_text`, `book_vision_description` |
+| `book_read` | Book reading (automatic on Book Menu close, or via the Capture Crosshair hotkey while reading — hotkey captures emit once after the menu closes) | `book_name`, `book_title`, `book_text`, `is_note`, `book_vision_description` |
 | `quest_stage` | Quest progression | `quest`, `quest_id`, `stage` |
 | `quest_start_stop` | Quest start/end | `quest`, `quest_id`, `started` (boolean) |
 | `location_change` | Location changed | `actor`, `from_location`, `to_location` |


### PR DESCRIPTION
## Summary

Template/docs companion to MinLL/SkyrimNet#882, which folded the manual book capture into the existing `book_read` event (the separate `book_read_manual` event type no longer exists).

## Changes

**`player_thoughts.prompt`**
- Remove the `book_read_manual` halves of both book conditions — the type is gone; manual captures fire `book_read`.
- Move the book branch above the combat branch in the user-section elif chain. Previously `is_in_combat` shadowed the book branch, so a book captured mid-fight rendered "React to Combat" with no book contents while the system section had already selected its book variant. Found via in-game test: a mid-combat capture produced a combat-panic thought that never saw the book text. Dialogue-choice mode and explicit thought topics keep their priority.
- Fence the book text in a code block so raw game text (font markup, line breaks) is clearly delimited from the surrounding instructions.

**`docs/modding/WORKFLOW_TRIGGERS.md`**
- Fold the `book_read_manual` row into `book_read`, documenting both triggers (automatic Book Menu close / Capture Crosshair hotkey) and the `is_note` / `book_vision_description` fields.

## Compatibility

Requires the Core changes from MinLL/SkyrimNet#882 (merged to dev): builds predating it emit `book_read_manual` for hotkey captures, which no longer matches the template's book branch.
