### PR TITLE
fix: stop dropping originator-less events from event history

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/components/event_history.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/event_history.prompt
@@ -13,7 +13,6 @@
 {% for event in events %}{% if event.type == "gamemaster_dialogue" %}{% set latestGMDialogueTime = event.gameTime %}{% endif %}{% endfor %}
 {% set hasShownGMDialogue = false %}
 {% for event in events %}
-{% if isValidActor(event.originatingActor) or event.type == "dialogue_background" %}
     {% if event.type != "spell" and event.type != "hit" and event.type != "combat" %}
         {% set locationChanged = (lastLocation != "" and event.location != lastLocation) %}
         {% set timeDiff = gameTimeNumeric - event.gameTime %}
@@ -85,7 +84,6 @@
         {% set lastEventLocation = event.location %}
         {% if showTimeGap or lastSignificantTime == 0 %}{% if existsIn(event, "gameTimeEnd") and event.gameTimeEnd %}{% set lastSignificantTime = event.gameTimeEnd %}{% else %}{% set lastSignificantTime = event.gameTime %}{% endif %}{% endif %}
     {% endif %}
-{% endif %}
 {% endfor %}
 {% if lastEventTime > 0 %}
     {% if exists("npc") and existsIn(npc, "UUID") %}{% set currentActorLocation = get_location(npc.UUID) %}{% else %}{% set currentActorLocation = location %}{% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/components/event_history_compact.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/event_history_compact.prompt
@@ -12,7 +12,6 @@
 {% for event in events %}{% if event.type == "gamemaster_dialogue" %}{% set latestGMDialogueTime = event.gameTime %}{% endif %}{% endfor %}
 {% set hasShownGMDialogue = false %}
 {% for event in events %}
-{% if isValidActor(event.originatingActor) or event.type == "dialogue_background" %}
     {% if event.type != "spell" and event.type != "hit" and event.type != "combat" %}
         {% set locationChanged = (lastLocation != "" and event.location != lastLocation) %}
         {% set timeDiff = gameTimeNumeric - event.gameTime %}
@@ -65,13 +64,12 @@
         {% else %}
 {# Telepathy: an NPC thought rendered into a different actor's prompt context (canonical-telepath audience expansion). Mark so the LLM doesn't read it as spoken dialogue. #}
 {% set _isTelepathyObserved = event.type == "npc_thoughts" and exists("npc") and existsIn(npc, "UUID") and event.originatingActor != npc.UUID %}
-- [{{ short_time(event.gameTimeStr) }}] {% if locationChanged %}[Now at {{ event.location }}] {% endif %}({{ event.type }}) {% if event.type == "dialogue" or event.type == "dialogue_npc" or event.type == "dialogue_player" or event.type == "dialogue_player_stt" or event.type == "dialogue_player_text" or event.type == "dialogue_background"%}{% if isValidActor(event.originatingActor) %}{{ get_name(event.originatingActor) }}{% if isValidActor(event.targetActor) %}{% if decnpc(event.targetActor).isVirtualPrivate and not _npc_is_private_virtual %}{% if decnpc(event.originatingActor).isFemale %} (talking to herself){% else %} (talking to himself){% endif %}{% else %} to {{ get_name(event.targetActor) }}{% endif %}{% endif %}: {% else if event.type == "dialogue_background" and event.data and event.data.speaker != "" %}{{ event.data.speaker }}: {% endif %}{% else %}{{ get_name(event.originatingActor) }}{% if _isTelepathyObserved %} (thought, telepathically observed){% endif %}: {% endif %}{{ format_event(event, "compact") }}
+- [{{ short_time(event.gameTimeStr) }}] {% if locationChanged %}[Now at {{ event.location }}] {% endif %}({{ event.type }}) {% if event.type == "dialogue" or event.type == "dialogue_npc" or event.type == "dialogue_player" or event.type == "dialogue_player_stt" or event.type == "dialogue_player_text" or event.type == "dialogue_background"%}{% if isValidActor(event.originatingActor) %}{{ get_name(event.originatingActor) }}{% if isValidActor(event.targetActor) %}{% if decnpc(event.targetActor).isVirtualPrivate and not _npc_is_private_virtual %}{% if decnpc(event.originatingActor).isFemale %} (talking to herself){% else %} (talking to himself){% endif %}{% else %} to {{ get_name(event.targetActor) }}{% endif %}{% endif %}: {% else if event.type == "dialogue_background" and event.data and event.data.speaker != "" %}{{ event.data.speaker }}: {% endif %}{% else %}{% if isValidActor(event.originatingActor) %}{{ get_name(event.originatingActor) }}{% if _isTelepathyObserved %} (thought, telepathically observed){% endif %}: {% endif %}{% endif %}{{ format_event(event, "compact") }}
         {% endif %}
 
         {% set lastLocation = event.location %}
         {% if showTimeGap or lastSignificantTime == 0 %}{% if existsIn(event, "gameTimeEnd") and event.gameTimeEnd %}{% set lastSignificantTime = event.gameTimeEnd %}{% else %}{% set lastSignificantTime = event.gameTime %}{% endif %}{% endif %}
     {% endif %}
-{% endif %}
 {% endfor %}
 {% if lastSignificantTime > 0 %}
     {% if exists("npc") and existsIn(npc, "UUID") %}{% set currentActorLocation = get_location(npc.UUID) %}{% else %}{% set currentActorLocation = location %}{% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/components/event_history_verbose.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/event_history_verbose.prompt
@@ -11,7 +11,7 @@
 {% set lastSignificantTime = 0 %}
 
 {% for event in events %}
-{% if (isValidActor(event.originatingActor) and event.type != "gamemaster_dialogue") or event.type == "dialogue_background" %}
+{% if event.type != "gamemaster_dialogue" %}
     {% if lastSignificantTime > 0 %}
         {% set timeSinceLastSignificant = event.gameTime - lastSignificantTime %}
     {% else %}
@@ -42,7 +42,7 @@
     {% else %}
 {# Telepathy: an NPC thought rendered into a different actor's prompt context (canonical-telepath audience expansion). Mark so the LLM doesn't read it as spoken dialogue. #}
 {% set _isTelepathyObserved = event.type == "npc_thoughts" and exists("npc") and existsIn(npc, "UUID") and event.originatingActor != npc.UUID %}
-[{{ short_time(event.gameTimeStr) }}] [{{ event.location }}] ({{ event.type }}) {% if event.type == "dialogue" or event.type == "dialogue_npc" or event.type == "dialogue_player" or event.type == "dialogue_player_stt" or event.type == "dialogue_player_text" or event.type == "dialogue_background" or event.type == "player_thoughts" %}{% if isValidActor(event.originatingActor) %}{{ get_name(event.originatingActor) }}{% if isValidActor(event.targetActor) %}{% if decnpc(event.targetActor).isVirtualPrivate and not _npc_is_private_virtual %}{% if decnpc(event.originatingActor).isFemale %} (talking to herself){% else %} (talking to himself){% endif %}{% else %} to {{ get_name(event.targetActor) }}{% endif %}{% endif %}: {% else if event.type == "dialogue_background" and event.data and event.data.speaker != "" %}{{ event.data.speaker }}: {% endif %}{% else %}{{ get_name(event.originatingActor) }}{% if _isTelepathyObserved %} (thought, telepathically observed){% endif %}: {% endif %}{{ format_event(event, "verbose") }}
+[{{ short_time(event.gameTimeStr) }}] [{{ event.location }}] ({{ event.type }}) {% if event.type == "dialogue" or event.type == "dialogue_npc" or event.type == "dialogue_player" or event.type == "dialogue_player_stt" or event.type == "dialogue_player_text" or event.type == "dialogue_background" or event.type == "player_thoughts" %}{% if isValidActor(event.originatingActor) %}{{ get_name(event.originatingActor) }}{% if isValidActor(event.targetActor) %}{% if decnpc(event.targetActor).isVirtualPrivate and not _npc_is_private_virtual %}{% if decnpc(event.originatingActor).isFemale %} (talking to herself){% else %} (talking to himself){% endif %}{% else %} to {{ get_name(event.targetActor) }}{% endif %}{% endif %}: {% else if event.type == "dialogue_background" and event.data and event.data.speaker != "" %}{{ event.data.speaker }}: {% endif %}{% else %}{% if isValidActor(event.originatingActor) %}{{ get_name(event.originatingActor) }}{% if _isTelepathyObserved %} (thought, telepathically observed){% endif %}: {% endif %}{% endif %}{{ format_event(event, "verbose") }}
     {% endif %}
 
     {% if existsIn(event, "gameTimeEnd") and event.gameTimeEnd %}{% set lastEventTime = event.gameTimeEnd %}{% else %}{% set lastEventTime = event.gameTime %}{% endif %}


### PR DESCRIPTION
## Problem

Player and NPC prompts were showing far fewer history events than the configured count. Diagnosed on a live playthrough: a player-thoughts prompt that fetched 15 events rendered only 6.

The C++ side fills the event window with the N most recent events involving the actor, but `components/event_history.prompt` (and its compact/verbose variants) gated every event on `isValidActor(event.originatingActor)`. Events registered without an originating actor — e.g. `acheron_downed`, `baka_execution` from third-party integrations, which carry the player only in `actor_UUIDs` — passed the fetch but were silently dropped at render. During a knockdown-heavy fight, 9 of the 15 fetched events were `acheron_downed`, so the visible history collapsed to 6 lines.

## Why the gate existed

It dates to the very first version of the template, when every rendered line was hardcoded as `decnpc(originatingActor).name: data` — the guard prevented rendering a name prefix for an unresolvable actor, and at the time the history contained only dialogue events, so it dropped nothing. When Beta3 (`9b17e970`) opened the history to all event types, the same commit added an inner `isValidActor` guard that renders originator-less events as bare data — but the outer gate was left in place, making that inner guard unreachable for exactly the events it was written to handle.

## Change

- Remove the outer `isValidActor` gate in all three variants. Originator-less events now render their formatted data without a name prefix (e.g. `[acheron_downed] Gunskjar [Reveler] is down`).
- Add the name-prefix validity guard to the generic branches of the compact/verbose variants (the main template already had it), so nameless events don't render a dangling `Name:` prefix.
- The verbose variant keeps its deliberate `gamemaster_dialogue` exclusion (`event.type != "gamemaster_dialogue"`).

## Side-effect verification (decorators called with 0 / unresolvable UUIDs)

- `isValidActor(0)` early-returns false (TRACE log only); `get_name(0)` returns `""` quietly.
- `format_event(event, "verbose")` on schema-less types uses the pure string fallback `[type] data` — no actor resolution, no game-thread work.
- `decnpc(...)` remains reachable only behind `isValidActor` guards.
- The vendored inja fork short-circuits `and`/`or` (lazily evaluated operands in `renderer.hpp`), so the `event.data.speaker` lookup in the else-if chain is never evaluated for non-`dialogue_background` events with string data; `PromptEngine` additionally sets `graceful_errors(true)`.
- The only origin-0 events observed in a real playthrough DB are `acheron_downed` and `baka_execution` — both meaningful narrative text; deliberate prompt exclusion is handled by the ephemeral/TTL system, not this gate.

`if`/`endif` and `for`/`endfor` balance verified on all three templates.
