### PR TITLE
feat: declare GetVirtualNPCUUID/GetVirtualNPCList natives

### DIFF
--- a/Source/Scripts/SkyrimNetApi.psc
+++ b/Source/Scripts/SkyrimNetApi.psc
@@ -457,6 +457,23 @@ int function EnableVirtualNPC(String name) Global Native
 ; Returns 0 on success, 1 on failure
 int function DisableVirtualNPC(String name) Global Native
 
+; Get the SkyrimNet entity UUID of a registered virtual NPC (uppercase hex, no "0x" prefix)
+; Virtual NPCs have no Actor, so GetEntityUUID cannot resolve them - use this instead.
+; - name: The registration name passed to RegisterVirtualNPC, or the display name. Case-insensitive.
+; Returns: The hex UUID, or an empty string if no enabled virtual NPC matches that name
+; Only enabled virtual NPCs resolve - call EnableVirtualNPC first.
+; Pair with DirectNarrationByUUID / RegisterDialogueByUUID / ExecuteActionByUUID / etc.
+; The UUID is derived from the registration name, so it is stable across sessions and safe to cache.
+String function GetVirtualNPCUUID(String name) Global Native
+
+; List every currently registered (enabled) virtual NPC
+; Returns: A JSON array string of {"name","displayName","uuid","voiceId","conversationMode"}
+;          objects, or "[]" if there are none
+; The built-in GetJson* helpers only read top-level object keys, so parsing this needs an
+; external JSON library (e.g. JContainers). For the common "I know the name" case use
+; GetVirtualNPCUUID instead - this is for discovery and diagnostics.
+String function GetVirtualNPCList() Global Native
+
 ; -----------------------------------------------------------------------------
 ; --- Web Interface ---
 ; -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes #443

Papyrus declarations for two new SkyrimNet natives:

- `String GetVirtualNPCUUID(String name)` — resolve a registered virtual NPC's entity UUID by registration name or display name (case-insensitive).
- `String GetVirtualNPCList()` — all registered virtual NPCs as a JSON array.

## Why
Virtual entities have no backing `Actor`, so `GetEntityUUID(Actor)` cannot resolve them — leaving no supported way to obtain the UUID that `DirectNarrationByUUID`, `RegisterDialogueByUUID`, `ExecuteActionByUUID`, `GenerateDiaryEntryByUUID` and `SetVoiceEffectByUUID` all require. The workaround was to give the V.E. a custom action, goad it into firing, and scrape the UUID from the callback.

`GetVirtualNPCUUID` returns the same uppercase-hex format as `GetEntityUUID`, so its result feeds those natives directly.

## Usage
```papyrus
SkyrimNetApi.RegisterVirtualNPC("MyGhost", "The Ghost", "malecommoner", "public", "")
SkyrimNetApi.EnableVirtualNPC("MyGhost")

String uuid = SkyrimNetApi.GetVirtualNPCUUID("MyGhost")   ; also accepts "The Ghost"
SkyrimNetApi.DirectNarrationByUUID("The ghost speaks.", uuid, "")
```

Only enabled virtual NPCs resolve — call `EnableVirtualNPC` first, or you get `""`. The UUID derives from the registration name, so it is stable across sessions and safe to cache.

## Companion PR
Implementation lives in SkyrimNet-Core: MinLL/SkyrimNet#886. Both must land for these natives to work.

## Test Plan
- [ ] Papyrus compiles against a SkyrimNet build containing MinLL/SkyrimNet#886
- [ ] `GetVirtualNPCUUID` returns non-empty hex for an enabled virtual NPC and `""` for an unknown one
- [ ] The returned UUID drives `DirectNarrationByUUID` successfully