### PR TITLE
chore: ignore the whole CppAPI/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ CLAUDE.local.md
 /SkyrimNet.esp
 
 PrismaUI/
-CppAPI/PublicAPI.h
+CppAPI/
 
 /external/SpriggitCLI-*
 Build_Config_Local.ps1


### PR DESCRIPTION
## What

`CppAPI/` receives generated headers copied in by the Core build. `.gitignore` listed only `CppAPI/PublicAPI.h`, so when Core PR #890 added `PublicAPIMemoryQuery.h` to that same post-build copy step, the new header started showing up as untracked.

Every Core build therefore left this repo dirty, which trips the clean check in `BuildAndBundle.ps1` and aborts a release before it tags anything.

Replaces the single-file rule with a directory rule, matching the `PrismaUI/` entry directly above it. Nothing under `CppAPI/` is tracked, so there is no index change.