### PR TITLE
Select Higgs audio tags by TTS capability

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0650_audio_tags.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0650_audio_tags.prompt
@@ -6,7 +6,7 @@
 
 {% if has_audio_tags and (dialogue_mode or thought_mode) %}
   {% set tts_engine = get_actor_tts(npc.UUID) %}
-  {% set useHiggsV3Tags = (tts_engine == "higgs" or tts_engine == "higgs_v3") and actor_tags_enabled %}
+  {% set useHiggsV3Tags = uses_higgs_native_tags(npc.UUID) %}
   {% set useChatterboxTags = tts_engine == "chatterbox" and actor_tags_enabled %}
 
   {% set chatterboxEmotionTags = ["[angry]", "[fear]", "[surprised]", "[whispering]", "[advertisement]", "[dramatic]", "[narration]","[happy]", "[sarcastic]"] %}


### PR DESCRIPTION
## Summary

Use the core uses_higgs_native_tags(npc.UUID) decorator when selecting the dialogue audio-tag format instead of hardcoding TTS engine IDs.

This keeps the prompt independent of whether Higgs is reached through the legacy connector, Boson.ai, or another OpenAI-compatible endpoint, while respecting the effective Higgs-tag configuration.