### PR TITLE
fix: restore mounted-state and tempered-equipment prompt coverage

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/components/context/component_npc_state_summary.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/context/component_npc_state_summary.prompt
@@ -9,9 +9,9 @@
     {% endif %}
     {% if is_unconscious(npc.UUID) %}
     - {{ npc.name }} is unconscious & unresponsive
-    {% elif mountName %}
-    - {{ npc.name }} is mounted on {{ mountName }}{% if mountRace %}, {{ mountRace }}{% endif %}
-    {% elif npc.furniture and npc.furniture != "None" %}
+    {% elif isString(mountName) and length(mountName) > 0 %}
+    - {{ npc.name }} is mounted on {{ mountName }}{% if isString(mountRace) and length(mountRace) > 0 %}, {{ mountRace }}{% endif %}
+    {% elif isString(npc.furniture) and length(npc.furniture) > 0 and npc.furniture != "None" %}
         {# Convert furniture name to lowercase for matching #}
         {% set furniture_lower = lower(npc.furniture) %}
         {% if length(npc.furniture) > 0 %}

--- a/SKSE/Plugins/SkyrimNet/prompts/components/context/component_npc_state_summary.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/context/component_npc_state_summary.prompt
@@ -2,12 +2,16 @@
 {% set nearby_npcs = get_nearby_npc_list(player.UUID) %}
 
 {% for npc in nearby_npcs %}
+    {% set mountName = is_mounted(npc.UUID) %}
+    {% set mountRace = get_mount_race(npc.UUID) %}
     {% if npc.isFollowing %}
         - {{ npc.name }} is following {{ player.name }}
     {% endif %}
     {% if is_unconscious(npc.UUID) %}
     - {{ npc.name }} is unconscious & unresponsive
-    {% elif npc.furniture != "None" %}
+    {% elif mountName %}
+    - {{ npc.name }} is mounted on {{ mountName }}{% if mountRace %}, {{ mountRace }}{% endif %}
+    {% elif npc.furniture and npc.furniture != "None" %}
         {# Convert furniture name to lowercase for matching #}
         {% set furniture_lower = lower(npc.furniture) %}
         {% if length(npc.furniture) > 0 %}

--- a/SKSE/Plugins/SkyrimNet/prompts/omnisight/describe_actor.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/omnisight/describe_actor.prompt
@@ -4,7 +4,7 @@
     **Character:** {{race}} {{gender}}
     {% if not omnisight_captures_equipment %}{% set actor_equipment = get_worn_equipment(actorUUID) %}{% set tempered_items = get_tempered_items(actorUUID) %}{% if actor_equipment and length(actor_equipment) > 0 %}
     **Equipment (reference only - describe only what's visible):**
-    {% for slot, item in actor_equipment %}{% if is_item_enabled(item.formID) %}{% set quality = "" %}{% for t in tempered_items %}{% if t.formID == item.formID and t.quality and length(t.quality) > 0 %}{% set quality = t.quality %}{% endif %}{% endfor %}    - {{ item.slot_body_area }}: {{ get_item_name(item.formID) }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %}
+    {% for slot, item in actor_equipment %}{% if is_item_enabled(item.formID) %}{% set quality = "" %}{% for t in tempered_items %}{% if t.formID == item.formID and isString(t.quality) and length(t.quality) > 0 %}{% set quality = t.quality %}{% endif %}{% endfor %}    - {{ item.slot_body_area }}: {{ get_item_name(item.formID) }}{% if isString(quality) and length(quality) > 0 %} [{{ quality }}]{% endif %}
     {% endif %}{% endfor %}{% endif %}{% endif %}
 
     ---

--- a/SKSE/Plugins/SkyrimNet/prompts/omnisight/describe_actor.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/omnisight/describe_actor.prompt
@@ -2,9 +2,9 @@
     Create a physical description of this character for a recognition database. Another AI will use your description to identify and remember this character without seeing the image.
 
     **Character:** {{race}} {{gender}}
-    {% if not omnisight_captures_equipment %}{% set actor_equipment = get_worn_equipment(actorUUID) %}{% if actor_equipment and length(actor_equipment) > 0 %}
+    {% if not omnisight_captures_equipment %}{% set actor_equipment = get_worn_equipment(actorUUID) %}{% set tempered_items = get_tempered_items(actorUUID) %}{% if actor_equipment and length(actor_equipment) > 0 %}
     **Equipment (reference only - describe only what's visible):**
-    {% for slot, item in actor_equipment %}{% if is_item_enabled(item.formID) %}    - {{ item.slot_body_area }}: {{ get_item_name(item.formID) }}
+    {% for slot, item in actor_equipment %}{% if is_item_enabled(item.formID) %}{% set quality = "" %}{% for t in tempered_items %}{% if t.formID == item.formID and t.quality and length(t.quality) > 0 %}{% set quality = t.quality %}{% endif %}{% endfor %}    - {{ item.slot_body_area }}: {{ get_item_name(item.formID) }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %}
     {% endif %}{% endfor %}{% endif %}{% endif %}
 
     ---

--- a/SKSE/Plugins/SkyrimNet/prompts/omnisight/describe_scene.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/omnisight/describe_scene.prompt
@@ -12,7 +12,9 @@
     ## Visible People (authoritative list; everyone below is on-camera):
     {% for npc in visibleNPCs %}
         {% set pos = get_actor_position_relative_to_camera(npc.UUID) %}
-        - {{npc.name}} ({{decnpc(npc.UUID).race}}, {{decnpc(npc.UUID).gender}}) — {{pos.meters}}m, {{pos.cardinalDirection}} {% if is_unconscious(npc.UUID) %}[UNCONSCIOUS] {% else %}{% if is_in_combat(npc.UUID) %}[COMBAT] {% endif %}{% if has_weapon_drawn(npc.UUID) %}[Armed] {% endif %}{% if is_swimming(npc.UUID) %}[Swimming]{% else if is_sprinting(npc.UUID) %}[Running]{% else if is_sneaking(npc.UUID) %}[Sneaking]{% endif %}{% endif %}
+        {% set mountName = is_mounted(npc.UUID) %}
+        {% set mountRace = get_mount_race(npc.UUID) %}
+        - {{npc.name}} ({{decnpc(npc.UUID).race}}, {{decnpc(npc.UUID).gender}}) — {{pos.meters}}m, {{pos.cardinalDirection}} {% if is_unconscious(npc.UUID) %}[UNCONSCIOUS] {% else %}{% if is_in_combat(npc.UUID) %}[COMBAT] {% endif %}{% if has_weapon_drawn(npc.UUID) %}[Armed] {% endif %}{% if mountName %}[Mounted: {{mountName}}{% if mountRace %}, {{mountRace}}{% endif %}]{% else if is_swimming(npc.UUID) %}[Swimming]{% else if is_sprinting(npc.UUID) %}[Running]{% else if is_sneaking(npc.UUID) %}[Sneaking]{% endif %}{% endif %}
     {% endfor %}
     {% else %}
     ## Visible People: (none detected)

--- a/SKSE/Plugins/SkyrimNet/prompts/omnisight/describe_scene.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/omnisight/describe_scene.prompt
@@ -14,7 +14,7 @@
         {% set pos = get_actor_position_relative_to_camera(npc.UUID) %}
         {% set mountName = is_mounted(npc.UUID) %}
         {% set mountRace = get_mount_race(npc.UUID) %}
-        - {{npc.name}} ({{decnpc(npc.UUID).race}}, {{decnpc(npc.UUID).gender}}) — {{pos.meters}}m, {{pos.cardinalDirection}} {% if is_unconscious(npc.UUID) %}[UNCONSCIOUS] {% else %}{% if is_in_combat(npc.UUID) %}[COMBAT] {% endif %}{% if has_weapon_drawn(npc.UUID) %}[Armed] {% endif %}{% if mountName %}[Mounted: {{mountName}}{% if mountRace %}, {{mountRace}}{% endif %}]{% else if is_swimming(npc.UUID) %}[Swimming]{% else if is_sprinting(npc.UUID) %}[Running]{% else if is_sneaking(npc.UUID) %}[Sneaking]{% endif %}{% endif %}
+        - {{npc.name}} ({{decnpc(npc.UUID).race}}, {{decnpc(npc.UUID).gender}}) — {{pos.meters}}m, {{pos.cardinalDirection}} {% if is_unconscious(npc.UUID) %}[UNCONSCIOUS] {% else %}{% if is_in_combat(npc.UUID) %}[COMBAT] {% endif %}{% if has_weapon_drawn(npc.UUID) %}[Armed] {% endif %}{% if isString(mountName) and length(mountName) > 0 %}[Mounted: {{mountName}}{% if isString(mountRace) and length(mountRace) > 0 %}, {{mountRace}}{% endif %}]{% else if is_swimming(npc.UUID) %}[Swimming]{% else if is_sprinting(npc.UUID) %}[Running]{% else if is_sneaking(npc.UUID) %}[Sneaking]{% endif %}{% endif %}
     {% endfor %}
     {% else %}
     ## Visible People: (none detected)

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0050_physical_activity.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0050_physical_activity.prompt
@@ -12,13 +12,13 @@
     ## Physical Activity
     {% if unconscious %}
         - {{ actor.name }} is currently unconscious and unable to move or act.
-    {% elif mountName %}
-        - {{ actor.name }} is currently mounted on {{ mountName }}{% if mountRace %}, {{ mountRace }}{% endif %}{% if sprinting %}, galloping at full speed{% endif %}.
+    {% elif isString(mountName) and length(mountName) > 0 %}
+        - {{ actor.name }} is currently mounted on {{ mountName }}{% if isString(mountRace) and length(mountRace) > 0 %}, {{ mountRace }}{% endif %}{% if sprinting %}, galloping at full speed{% endif %}.
     {% elif swimming %}
         - {{ actor.name }} is currently swimming.
     {% elif sprinting %}
         - {{ actor.name }} is currently sprinting at full speed.
-    {% elif furniture %}
+    {% elif isString(furniture) and length(furniture) > 0 %}
         - {{ actor.name }} is currently using a {{ furniture }}.
     {% elif knockedDown %}
         - {{ actor.name }} is currently badly wounded, and is kneeling on the ground.

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0050_physical_activity.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0050_physical_activity.prompt
@@ -5,27 +5,28 @@
     {% set sprinting = is_sprinting(actorUUID) %}
     {% set swimming = is_swimming(actorUUID) %}
     {% set knockedDown = is_knocked_down(actorUUID) %}
-    {% if unconscious or sneaking or walking or sprinting or swimming or knockedDown %}
-        {% set actor = decnpc(actorUUID) %}
-        ## Physical Activity
-        {% if unconscious %}
-            - {{ actor.name }} is currently unconscious and unable to move or act.
-        {% else %}
-            {% if sneaking %}
-                - {{ actor.name }} is currently trying to move silently, and avoid being seen or heard.
-            {% endif %}
-            {% if walking %}
-                - {{ actor.name }} is currently walking at a steady pace.
-            {% endif %}
-            {% if sprinting %}
-                - {{ actor.name }} is currently sprinting at full speed.
-            {% endif %}
-            {% if swimming %}
-                - {{ actor.name }} is currently swimming.
-            {% endif %}
-            {% if knockedDown %}
-                - {{ actor.name }} is currently badly wounded, and is kneeling on the ground.
-            {% endif %}
-        {% endif %}
+    {% set mountName = is_mounted(actorUUID) %}
+    {% set mountRace = get_mount_race(actorUUID) %}
+    {% set furniture = get_furniture(actorUUID) %}
+    {% set actor = decnpc(actorUUID) %}
+    ## Physical Activity
+    {% if unconscious %}
+        - {{ actor.name }} is currently unconscious and unable to move or act.
+    {% elif mountName %}
+        - {{ actor.name }} is currently mounted on {{ mountName }}{% if mountRace %}, {{ mountRace }}{% endif %}{% if sprinting %}, galloping at full speed{% endif %}.
+    {% elif swimming %}
+        - {{ actor.name }} is currently swimming.
+    {% elif sprinting %}
+        - {{ actor.name }} is currently sprinting at full speed.
+    {% elif furniture %}
+        - {{ actor.name }} is currently using a {{ furniture }}.
+    {% elif knockedDown %}
+        - {{ actor.name }} is currently badly wounded, and is kneeling on the ground.
+    {% elif sneaking %}
+        - {{ actor.name }} is currently trying to move silently, and avoid being seen or heard.
+    {% elif walking %}
+        - {{ actor.name }} is currently walking at a steady pace.
+    {% else %}
+        - {{ actor.name }} is currently able to move normally.
     {% endif %}
 {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0410_equipment.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0410_equipment.prompt
@@ -19,14 +19,14 @@
             {% endif %}
             {% set quality = "" %}
             {% for t in tempered_items %}
-                {% if t.formID == item.formID and t.quality and length(t.quality) > 0 %}
+                {% if t.formID == item.formID and isString(t.quality) and length(t.quality) > 0 %}
                     {% set quality = t.quality %}
                 {% endif %}
             {% endfor %}
             {% if item.equipment_slot == "leftHand" or item.equipment_slot == "rightHand" %}
-                - {% if length(item_desc) > 0 %}{{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %} - {{ item_desc }}{% else %}**{{ item.equipment_slot }}**: {{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %}{% endif %} {% if has_weapon_drawn(actorUUID) %}(drawn){% else %}(sheathed){% endif %}
+                - {% if length(item_desc) > 0 %}{{ item_name }}{% if isString(quality) and length(quality) > 0 %} [{{ quality }}]{% endif %} - {{ item_desc }}{% else %}**{{ item.equipment_slot }}**: {{ item_name }}{% if isString(quality) and length(quality) > 0 %} [{{ quality }}]{% endif %}{% endif %} {% if has_weapon_drawn(actorUUID) %}(drawn){% else %}(sheathed){% endif %}
             {% else %}
-                - {% if length(item_desc) > 0 %}{{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %} - {{ item_desc }}{% else %}**{{ item.slot_body_area }}**: {{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %}{% endif %}
+                - {% if length(item_desc) > 0 %}{{ item_name }}{% if isString(quality) and length(quality) > 0 %} [{{ quality }}]{% endif %} - {{ item_desc }}{% else %}**{{ item.slot_body_area }}**: {{ item_name }}{% if isString(quality) and length(quality) > 0 %} [{{ quality }}]{% endif %}{% endif %}
             {% endif %} {# end left hand / right hand check #}
         {% endif %}{# end is item enabled #}
     {% endfor %}
@@ -54,14 +54,14 @@
                 {% endif %}
                 {% set quality = "" %}
                 {% for t in tempered_items %}
-                    {% if t.formID == item.formID and t.quality and length(t.quality) > 0 %}
+                    {% if t.formID == item.formID and isString(t.quality) and length(t.quality) > 0 %}
                         {% set quality = t.quality %}
                     {% endif %}
                 {% endfor %}
                 {% if item.equipment_slot == "leftHand" or item.equipment_slot == "rightHand" %}
-                    - {% if length(item_desc) > 0 %}{{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %} - {{ item_desc }}{% else %}**{{ item.equipment_slot }}**: {{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %}{% endif %} {% if has_weapon_drawn(responseTarget.UUID) %}(drawn){% else %}(sheathed){% endif %}
+                    - {% if length(item_desc) > 0 %}{{ item_name }}{% if isString(quality) and length(quality) > 0 %} [{{ quality }}]{% endif %} - {{ item_desc }}{% else %}**{{ item.equipment_slot }}**: {{ item_name }}{% if isString(quality) and length(quality) > 0 %} [{{ quality }}]{% endif %}{% endif %} {% if has_weapon_drawn(responseTarget.UUID) %}(drawn){% else %}(sheathed){% endif %}
                 {% else %}
-                    - {% if length(item_desc) > 0 %}{{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %} - {{ item_desc }}{% else %}**{{ item.slot_body_area }}**: {{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %}{% endif %}
+                    - {% if length(item_desc) > 0 %}{{ item_name }}{% if isString(quality) and length(quality) > 0 %} [{{ quality }}]{% endif %} - {{ item_desc }}{% else %}**{{ item.slot_body_area }}**: {{ item_name }}{% if isString(quality) and length(quality) > 0 %} [{{ quality }}]{% endif %}{% endif %}
                 {% endif %} {# end left hand / right hand check #}
             {% endif %}{# end is item enabled #}
         {% endfor %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0410_equipment.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0410_equipment.prompt
@@ -1,6 +1,7 @@
 {% if render_mode == "full" or render_mode == "thoughts" or render_mode == "transform" or render_mode == "equipment" %}
     ### Worn Equipment
     {% set npc_equipment = get_worn_equipment(actorUUID) %}
+    {% set tempered_items = get_tempered_items(actorUUID) %}
     {% for slot, item in npc_equipment %}
         {% if is_item_enabled(item.formID) %}
             {# Try OmniSight name/description (gender-aware) first, then fall back to item customization #}
@@ -16,10 +17,16 @@
             {% else %}
                 {% set item_desc = get_item_description(item.formID) %}
             {% endif %}
+            {% set quality = "" %}
+            {% for t in tempered_items %}
+                {% if t.formID == item.formID and t.quality and length(t.quality) > 0 %}
+                    {% set quality = t.quality %}
+                {% endif %}
+            {% endfor %}
             {% if item.equipment_slot == "leftHand" or item.equipment_slot == "rightHand" %}
-                - {% if length(item_desc) > 0 %}{{ item_name }} - {{ item_desc }}{% else %}**{{ item.equipment_slot }}**: {{ item_name }}{% endif %} {% if has_weapon_drawn(actorUUID) %}(drawn){% else %}(sheathed){% endif %}
+                - {% if length(item_desc) > 0 %}{{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %} - {{ item_desc }}{% else %}**{{ item.equipment_slot }}**: {{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %}{% endif %} {% if has_weapon_drawn(actorUUID) %}(drawn){% else %}(sheathed){% endif %}
             {% else %}
-                - {% if length(item_desc) > 0 %}{{ item_name }} - {{ item_desc }}{% else %}**{{ item.slot_body_area }}**: {{ item_name }}{% endif %}
+                - {% if length(item_desc) > 0 %}{{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %} - {{ item_desc }}{% else %}**{{ item.slot_body_area }}**: {{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %}{% endif %}
             {% endif %} {# end left hand / right hand check #}
         {% endif %}{# end is item enabled #}
     {% endfor %}
@@ -29,6 +36,7 @@
     {% if responseTarget and responseTarget.UUID != 0 %}
         ### Worn Equipment
         {% set target_equipment = get_worn_equipment(responseTarget.UUID) %}
+        {% set tempered_items = get_tempered_items(responseTarget.UUID) %}
         {% for slot, item in target_equipment %}
             {% if is_item_enabled(item.formID) %}
                 {# Try OmniSight name/description (gender-aware) first, then fall back to item customization #}
@@ -44,10 +52,16 @@
                 {% else %}
                     {% set item_desc = get_item_description(item.formID) %}
                 {% endif %}
+                {% set quality = "" %}
+                {% for t in tempered_items %}
+                    {% if t.formID == item.formID and t.quality and length(t.quality) > 0 %}
+                        {% set quality = t.quality %}
+                    {% endif %}
+                {% endfor %}
                 {% if item.equipment_slot == "leftHand" or item.equipment_slot == "rightHand" %}
-                    - {% if length(item_desc) > 0 %}{{ item_name }} - {{ item_desc }}{% else %}**{{ item.equipment_slot }}**: {{ item_name }}{% endif %} {% if has_weapon_drawn(responseTarget.UUID) %}(drawn){% else %}(sheathed){% endif %}
+                    - {% if length(item_desc) > 0 %}{{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %} - {{ item_desc }}{% else %}**{{ item.equipment_slot }}**: {{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %}{% endif %} {% if has_weapon_drawn(responseTarget.UUID) %}(drawn){% else %}(sheathed){% endif %}
                 {% else %}
-                    - {% if length(item_desc) > 0 %}{{ item_name }} - {{ item_desc }}{% else %}**{{ item.slot_body_area }}**: {{ item_name }}{% endif %}
+                    - {% if length(item_desc) > 0 %}{{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %} - {{ item_desc }}{% else %}**{{ item.slot_body_area }}**: {{ item_name }}{% if length(quality) > 0 %} [{{ quality }}]{% endif %}{% endif %}
                 {% endif %} {# end left hand / right hand check #}
             {% endif %}{# end is item enabled #}
         {% endfor %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0300_equipment_decorators.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0300_equipment_decorators.prompt
@@ -100,7 +100,7 @@
 **Tempered Items:**
 {% if temperedItems and length(temperedItems) > 0 %}
 {% for data in temperedItems %}
-- FormID: {{ data.formID }} | Quality: {% if data.quality %}{{ data.quality }}{% else %}No quality{% endif %} | Health: {{ data.healthPercent }}%
+- FormID: {{ data.formID }} | Quality: {% if isString(data.quality) and length(data.quality) > 0 %}{{ data.quality }}{% else %}No quality{% endif %} | Health: {{ data.healthPercent }}%
 {% endfor %}
 {% else %}
 No tempered weapons or armor found.
@@ -112,11 +112,11 @@ No tempered weapons or armor found.
 {% if item %}
 {% set itemQuality = "" %}
 {% for data in temperedItems %}
-{% if data.formID == item.formID and data.quality %}
+{% if data.formID == item.formID and isString(data.quality) and length(data.quality) > 0 %}
 {% set itemQuality = data.quality %}
 {% endif %}
 {% endfor %}
-- {{ slot }}: {{ item.name }}{% if itemQuality %} [{{ itemQuality }}]{% endif %}
+- {{ slot }}: {{ item.name }}{% if isString(itemQuality) and length(itemQuality) > 0 %} [{{ itemQuality }}]{% endif %}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0300_equipment_decorators.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0300_equipment_decorators.prompt
@@ -93,7 +93,37 @@
 
 ---
 
-### Test 2: worn_has_keyword() - Equipment Keyword Checks
+### Test 2: get_tempered_items() - Tempered Equipment
+
+{% set temperedItems = get_tempered_items(actorUUID) %}
+
+**Tempered Items:**
+{% if temperedItems and length(temperedItems) > 0 %}
+{% for data in temperedItems %}
+- FormID: {{ data.formID }} | Quality: {% if data.quality %}{{ data.quality }}{% else %}No quality{% endif %} | Health: {{ data.healthPercent }}%
+{% endfor %}
+{% else %}
+No tempered weapons or armor found.
+{% endif %}
+
+**Tempered Quality on Worn Equipment:**
+{% if not has_key(equipment, "error") %}
+{% for slot, item in equipment %}
+{% if item %}
+{% set itemQuality = "" %}
+{% for data in temperedItems %}
+{% if data.formID == item.formID and data.quality %}
+{% set itemQuality = data.quality %}
+{% endif %}
+{% endfor %}
+- {{ slot }}: {{ item.name }}{% if itemQuality %} [{{ itemQuality }}]{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+---
+
+### Test 3: worn_has_keyword() - Equipment Keyword Checks
 
 **Armor Type Keywords:**
 - ArmorHeavy: {% if worn_has_keyword(actorUUID, "ArmorHeavy") %}✓ YES{% else %}✗ NO{% endif %}
@@ -126,7 +156,7 @@
 
 ---
 
-### Test 3: get_inventory() - Full Inventory
+### Test 4: get_inventory() - Full Inventory
 
 {% set inventory = get_inventory(actorUUID) %}
 
@@ -154,7 +184,7 @@
 
 ---
 
-### Test 4: Player Equipment Comparison
+### Test 5: Player Equipment Comparison
 
 {% set playerEquip = get_worn_equipment(player.UUID) %}
 
@@ -179,7 +209,7 @@ Player armor type unknown
 
 ---
 
-### Test 5: get_merchant_inventory() - Merchant Shop Items
+### Test 6: get_merchant_inventory() - Merchant Shop Items
 
 {# Gets items for sale from a merchant's faction container (separate from personal inventory) #}
 

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0700_scene_world_decorators.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0700_scene_world_decorators.prompt
@@ -199,23 +199,27 @@ Events involving Player: {{ length(playerEvents) }}
 {% set playerFurniture = get_furniture(player.UUID) %}
 
 **Actor Movement States:**
-- {{ actorName }} is_sneaking: {% if actorMountName %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sneaking(actorUUID) %}🤫 SNEAKING{% else %}✗ Not sneaking{% endif %}
-- {{ actorName }} is_sprinting: {% if actorMountName %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sprinting(actorUUID) %}🏃 SPRINTING{% else %}✗ Not sprinting{% endif %}
+- Actor cached mount name: isString={{ isString(actorMountName) }}, length={% if isString(actorMountName) %}{{ length(actorMountName) }}{% else %}N/A{% endif %}, value={{ actorMountName }}
+- Actor cached mount race: isString={{ isString(actorMountRace) }}, length={% if isString(actorMountRace) %}{{ length(actorMountRace) }}{% else %}N/A{% endif %}, value={{ actorMountRace }}
+- {{ actorName }} is_sneaking: {% if isString(actorMountName) and length(actorMountName) > 0 %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sneaking(actorUUID) %}🤫 SNEAKING{% else %}✗ Not sneaking{% endif %}
+- {{ actorName }} is_sprinting: {% if isString(actorMountName) and length(actorMountName) > 0 %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sprinting(actorUUID) %}🏃 SPRINTING{% else %}✗ Not sprinting{% endif %}
 - {{ actorName }} is_walking: {% if is_walking(actorUUID) %}🚶 WALKING{% else %}✗ Not walking{% endif %}
 - {{ actorName }} is_swimming: {% if is_swimming(actorUUID) %}🏊 SWIMMING{% else %}✗ Not swimming{% endif %}
 - {{ actorName }} is_unconscious: {% if is_unconscious(actorUUID) %}💤 UNCONSCIOUS{% else %}✗ Conscious{% endif %}
-- {{ actorName }} is_mounted: {% if actorMountName %}✓ TRUE - Mounted on {{ actorMountName }}{% else %}✗ FALSE - Not mounted{% endif %}
-- {{ actorName }} mount race: {% if actorMountName and actorMountRace %}{{ actorMountRace }}{% else %}N/A{% endif %}
-- {{ actorName }} furniture: {% if actorFurniture %}{{ actorFurniture }}{% else %}None{% endif %}
+- {{ actorName }} is_mounted: {% if isString(actorMountName) and length(actorMountName) > 0 %}✓ TRUE - Mounted on {{ actorMountName }}{% else %}✗ FALSE - Not mounted{% endif %}
+- {{ actorName }} mount race: {% if isString(actorMountName) and length(actorMountName) > 0 and isString(actorMountRace) and length(actorMountRace) > 0 %}{{ actorMountRace }}{% else %}N/A{% endif %}
+- {{ actorName }} furniture: {% if isString(actorFurniture) and length(actorFurniture) > 0 %}{{ actorFurniture }}{% else %}None{% endif %}
 
 **Player Movement States:**
-- Player is_sneaking: {% if playerMountName %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sneaking(player.UUID) %}🤫 SNEAKING{% else %}✗ Not sneaking{% endif %}
-- Player is_sprinting: {% if playerMountName %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sprinting(player.UUID) %}🏃 SPRINTING{% else %}✗ Not sprinting{% endif %}
+- Player cached mount name: isString={{ isString(playerMountName) }}, length={% if isString(playerMountName) %}{{ length(playerMountName) }}{% else %}N/A{% endif %}, value={{ playerMountName }}
+- Player cached mount race: isString={{ isString(playerMountRace) }}, length={% if isString(playerMountRace) %}{{ length(playerMountRace) }}{% else %}N/A{% endif %}, value={{ playerMountRace }}
+- Player is_sneaking: {% if isString(playerMountName) and length(playerMountName) > 0 %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sneaking(player.UUID) %}🤫 SNEAKING{% else %}✗ Not sneaking{% endif %}
+- Player is_sprinting: {% if isString(playerMountName) and length(playerMountName) > 0 %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sprinting(player.UUID) %}🏃 SPRINTING{% else %}✗ Not sprinting{% endif %}
 - Player is_walking: {% if is_walking(player.UUID) %}🚶 WALKING{% else %}✗ Not walking{% endif %}
 - Player is_swimming: {% if is_swimming(player.UUID) %}🏊 SWIMMING{% else %}✗ Not swimming{% endif %}
-- Player is_mounted: {% if playerMountName %}✓ TRUE - Mounted on {{ playerMountName }}{% else %}✗ FALSE - Not mounted{% endif %}
-- Player mount race: {% if playerMountName and playerMountRace %}{{ playerMountRace }}{% else %}N/A{% endif %}
-- Player furniture: {% if playerFurniture %}{{ playerFurniture }}{% else %}None{% endif %}
+- Player is_mounted: {% if isString(playerMountName) and length(playerMountName) > 0 %}✓ TRUE - Mounted on {{ playerMountName }}{% else %}✗ FALSE - Not mounted{% endif %}
+- Player mount race: {% if isString(playerMountName) and length(playerMountName) > 0 and isString(playerMountRace) and length(playerMountRace) > 0 %}{{ playerMountRace }}{% else %}N/A{% endif %}
+- Player furniture: {% if isString(playerFurniture) and length(playerFurniture) > 0 %}{{ playerFurniture }}{% else %}None{% endif %}
 
 ---
 

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0700_scene_world_decorators.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0700_scene_world_decorators.prompt
@@ -199,8 +199,6 @@ Events involving Player: {{ length(playerEvents) }}
 {% set playerFurniture = get_furniture(player.UUID) %}
 
 **Actor Movement States:**
-- Actor cached mount name: isString={{ isString(actorMountName) }}, length={% if isString(actorMountName) %}{{ length(actorMountName) }}{% else %}N/A{% endif %}, value={{ actorMountName }}
-- Actor cached mount race: isString={{ isString(actorMountRace) }}, length={% if isString(actorMountRace) %}{{ length(actorMountRace) }}{% else %}N/A{% endif %}, value={{ actorMountRace }}
 - {{ actorName }} is_sneaking: {% if isString(actorMountName) and length(actorMountName) > 0 %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sneaking(actorUUID) %}🤫 SNEAKING{% else %}✗ Not sneaking{% endif %}
 - {{ actorName }} is_sprinting: {% if isString(actorMountName) and length(actorMountName) > 0 %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sprinting(actorUUID) %}🏃 SPRINTING{% else %}✗ Not sprinting{% endif %}
 - {{ actorName }} is_walking: {% if is_walking(actorUUID) %}🚶 WALKING{% else %}✗ Not walking{% endif %}
@@ -211,8 +209,6 @@ Events involving Player: {{ length(playerEvents) }}
 - {{ actorName }} furniture: {% if isString(actorFurniture) and length(actorFurniture) > 0 %}{{ actorFurniture }}{% else %}None{% endif %}
 
 **Player Movement States:**
-- Player cached mount name: isString={{ isString(playerMountName) }}, length={% if isString(playerMountName) %}{{ length(playerMountName) }}{% else %}N/A{% endif %}, value={{ playerMountName }}
-- Player cached mount race: isString={{ isString(playerMountRace) }}, length={% if isString(playerMountRace) %}{{ length(playerMountRace) }}{% else %}N/A{% endif %}, value={{ playerMountRace }}
 - Player is_sneaking: {% if isString(playerMountName) and length(playerMountName) > 0 %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sneaking(player.UUID) %}🤫 SNEAKING{% else %}✗ Not sneaking{% endif %}
 - Player is_sprinting: {% if isString(playerMountName) and length(playerMountName) > 0 %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sprinting(player.UUID) %}🏃 SPRINTING{% else %}✗ Not sprinting{% endif %}
 - Player is_walking: {% if is_walking(player.UUID) %}🚶 WALKING{% else %}✗ Not walking{% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0700_scene_world_decorators.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/test_decorators/0700_scene_world_decorators.prompt
@@ -191,18 +191,31 @@ Events involving Player: {{ length(playerEvents) }}
 
 ### Test 7: Movement State Decorators
 
+{% set actorMountName = is_mounted(actorUUID) %}
+{% set actorMountRace = get_mount_race(actorUUID) %}
+{% set actorFurniture = get_furniture(actorUUID) %}
+{% set playerMountName = is_mounted(player.UUID) %}
+{% set playerMountRace = get_mount_race(player.UUID) %}
+{% set playerFurniture = get_furniture(player.UUID) %}
+
 **Actor Movement States:**
-- {{ actorName }} is_sneaking: {% if is_sneaking(actorUUID) %}🤫 SNEAKING{% else %}✗ Not sneaking{% endif %}
-- {{ actorName }} is_sprinting: {% if is_sprinting(actorUUID) %}🏃 SPRINTING{% else %}✗ Not sprinting{% endif %}
+- {{ actorName }} is_sneaking: {% if actorMountName %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sneaking(actorUUID) %}🤫 SNEAKING{% else %}✗ Not sneaking{% endif %}
+- {{ actorName }} is_sprinting: {% if actorMountName %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sprinting(actorUUID) %}🏃 SPRINTING{% else %}✗ Not sprinting{% endif %}
 - {{ actorName }} is_walking: {% if is_walking(actorUUID) %}🚶 WALKING{% else %}✗ Not walking{% endif %}
 - {{ actorName }} is_swimming: {% if is_swimming(actorUUID) %}🏊 SWIMMING{% else %}✗ Not swimming{% endif %}
 - {{ actorName }} is_unconscious: {% if is_unconscious(actorUUID) %}💤 UNCONSCIOUS{% else %}✗ Conscious{% endif %}
+- {{ actorName }} is_mounted: {% if actorMountName %}✓ TRUE - Mounted on {{ actorMountName }}{% else %}✗ FALSE - Not mounted{% endif %}
+- {{ actorName }} mount race: {% if actorMountName and actorMountRace %}{{ actorMountRace }}{% else %}N/A{% endif %}
+- {{ actorName }} furniture: {% if actorFurniture %}{{ actorFurniture }}{% else %}None{% endif %}
 
 **Player Movement States:**
-- Player is_sneaking: {% if is_sneaking(player.UUID) %}🤫 SNEAKING{% else %}✗ Not sneaking{% endif %}
-- Player is_sprinting: {% if is_sprinting(player.UUID) %}🏃 SPRINTING{% else %}✗ Not sprinting{% endif %}
+- Player is_sneaking: {% if playerMountName %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sneaking(player.UUID) %}🤫 SNEAKING{% else %}✗ Not sneaking{% endif %}
+- Player is_sprinting: {% if playerMountName %}⏸ SUPPRESSED WHILE MOUNTED{% elif is_sprinting(player.UUID) %}🏃 SPRINTING{% else %}✗ Not sprinting{% endif %}
 - Player is_walking: {% if is_walking(player.UUID) %}🚶 WALKING{% else %}✗ Not walking{% endif %}
 - Player is_swimming: {% if is_swimming(player.UUID) %}🏊 SWIMMING{% else %}✗ Not swimming{% endif %}
+- Player is_mounted: {% if playerMountName %}✓ TRUE - Mounted on {{ playerMountName }}{% else %}✗ FALSE - Not mounted{% endif %}
+- Player mount race: {% if playerMountName and playerMountRace %}{{ playerMountRace }}{% else %}N/A{% endif %}
+- Player furniture: {% if playerFurniture %}{{ playerFurniture }}{% else %}None{% endif %}
 
 ---
 


### PR DESCRIPTION
## Summary

Reconstructs mounted and tempered awareness across seven prompt files, consuming the decorator interfaces already integrated in core PR #799. The prompt-side changes from PRs #399/#403 were never merged — this restores that missing coverage.

**Pair PR**: MinLL/SkyrimNet#1049 (core `is_mounted` display-name fallback fix + docs)

## Changes

- **Movement precedence** (0050_physical_activity): exclusive if/elif chain — unconscious > mounted > swimming > sprinting > furniture > knocked down > sneaking > walking
- **Mounted suppression**: sneaking and sprinting suppressed when mounted; sprint becomes "galloping" within the mounted sentence
- **Tempered equipment** (0410_equipment, describe_actor): `get_tempered_items(uuid)` called once per actor context, matched by integer `formID`, rendered as `ItemName [QualityLabel]` — applied to normal actor, dialogue-target, and OmniSight actor views
- **Scene tags** (describe_scene): mounted state tag `[Mounted: name, race]` in the movement bracket output, respecting unconscious precedence
- **NPC state** (component_npc_state_summary): mounted elif between unconscious and furniture checks
- **Test decorators** (0300, 0700): new test sections for tempered items and mounted/furniture state

## Testing

- [x] Manual / in-game testing performed — scenarios:
  - **Mounted state** (5 PASS, 1 BLOCKED): mount/dismount, named horse display name, sneak/sprint suppression while mounted, galloping output on sprint. Unconscious+mounted blocked (Skyrim dismounts on collapse; static inspection confirms correct precedence).
  - **Movement precedence** (5 PASS, 2 FAIL — pre-existing): swim, sprint, furniture, knocked-down, sneak all correct. Two `is_walking` failures are pre-existing engine issues (`RE::ActorState::IsWalking` gait flag unreliable) — out of scope.
  - **Tempered equipment** (5 PASS): weapon/armor quality suffix, untempered unchanged, multiple items, dialogue-target quality.
  - **OmniSight** (2 NOT RUN, low priority): no mounted NPC encountered in vanilla. Decorator path identical to player-mounted (proven). Will verify opportunistically.

## Known Issues Discovered (out of scope)

- **`is_walking` gait flag unreliable**: stationary NPCs report walking; moving player doesn't. Needs investigation into animation graph `Speed` or another movement signal. Tracked in `.opencode/docs/follow-ups/is-walking-actual-movement.md`.
- **Carriage furniture detection**: ADT carriage seats aren't detected by `GetOccupiedFurniture()`. Bjorlam shows `furniture: []` while visibly seated in a carriage. Tracked in `.opencode/docs/follow-ups/carriage-furniture-detection.md`.

## Documentation

- [x] Pair PR updates `ai_docs/TEMPLATES.md` with corrected decorator descriptions