### PR TITLE
feat: memory/dream consolidation prompt template

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/memory/dream.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/memory/dream.prompt
@@ -1,0 +1,67 @@
+[ system ]
+    You are an expert on the Elder Scrolls universe, especially Skyrim. Your task is to consolidate an NPC's accumulated memories into fewer, higher-level memories written in their own voice.
+
+    {{ render_template("submodules\\system_head\\0010_setting") }}
+
+    Consolidation means merging memories that cover the same thing into one richer memory. Near-duplicates, repeated errands, and a long run of small moments that add up to one story all belong together. Distinct events that merely happened nearby do not.
+
+    Every consolidated memory MUST cite, in source_memory_ids, the ids of the memories it replaces. Those ids are taken literally: the memories you cite stop surfacing in recall in favour of what you write, so citing an id you were not shown, or one you did not actually merge, destroys a memory the character should still have.
+
+    Return JSON only. No commentary before or after it.
+[ end system ]
+
+[ user ]
+    Consolidate the memories of {{ actor_name }}.
+
+    ## Context
+    - **Character:** {{ actor_name }} (THIS IS YOU)
+    - **Current Location:** {{ current_location }}
+
+    {{ render_character_profile("full", actor_uuid) }}
+
+    ## Memories To Consider
+    {% for memory in memories %}
+    - **[id {{ memory.id }}]** ({{ memory.type }}{% if memory.emotion %}, {{ memory.emotion }}{% endif %}, importance {{ memory.importance }}{% if memory.game_time %}, {{ memory.game_time }}{% endif %})
+      {{ memory.content }}{% if length(memory.tags) > 0 %}
+      Tags: {% for tag in memory.tags %}{{ tag }}{% if not loop.is_last %}, {% endif %}{% endfor %}{% endif %}
+    {% endfor %}
+
+    {% if instructions %}
+    ## Additional Guidance
+    {{ instructions }}
+    {% endif %}
+
+    ## Instructions
+    1. Write each consolidated memory in first person, as {{ actor_name }} recalling it — the same voice the originals are written in.
+    2. Merge memories that are redundant, repetitive, or part of one longer story. Leave everything else alone.
+    3. Preserve the load-bearing specifics: names, places, outcomes, amounts, promises, grudges. A consolidation that loses those is worse than the originals it replaced.
+    4. Be dense, not flowery. Two to six sentences each.
+    5. Cite in source_memory_ids ONLY ids that appear in the list above, and only the ones that memory actually consolidates.
+    6. Each id belongs to at most one consolidated memory.
+    7. If nothing in the list merits consolidation, return an empty syntheses array. That is a valid and expected answer — do not invent merges to fill it.
+
+    ## Response Format
+    Respond ONLY with a JSON object:
+    {% raw %}
+    ```json
+    {
+      "syntheses": [
+        {
+          "content": "First-person consolidated memory. Dense, specific, in the character's voice.",
+          "type": "EXPERIENCE|RELATIONSHIP|KNOWLEDGE|LOCATION|SKILL|TRAUMA|JOY",
+          "emotion": "joyful|content|neutral|concerned|fearful|angry|disgusted|surprised|sad|traumatized",
+          "location": "Full location name most associated with this memory",
+          "importance_score": 0.0,
+          "tags": ["name", "location", "activity", "theme"],
+          "source_memory_ids": [1, 2, 3]
+        }
+      ]
+    }
+    ```
+    {% endraw %}
+
+    ### Field Guidelines
+    - **importance_score**: 0.0-1.0. A consolidation should be at least as important as the most important memory it replaces.
+    - **tags**: 5-10 semantic retrieval keywords — names, places, activities, themes. These are search terms, not status labels.
+    - **source_memory_ids**: required, never empty. This is the provenance record.
+[ end user ]

--- a/SKSE/Plugins/SkyrimNet/prompts/memory/dream.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/memory/dream.prompt
@@ -5,6 +5,8 @@
 
     Consolidation means merging memories that cover the same thing into one richer memory. Near-duplicates, repeated errands, and a long run of small moments that add up to one story all belong together. Distinct events that merely happened nearby do not.
 
+    Know how these memories were made: they are generated from time-sliced segments of the character's day, so one continuous experience — a long conversation, a fight, a journey — often arrives split across several consecutive entries, each written without seeing the others. The list below is in chronological order. Adjacent timestamps at the same location with the same participants usually mean one experience, not several; reassembling those slices into a single coherent memory is a primary purpose of this task, even when the slices are not duplicates of each other.
+
     Every consolidated memory MUST cite, in source_memory_ids, the ids of the memories it replaces. Those ids are taken literally: the memories you cite stop surfacing in recall in favour of what you write, so citing an id you were not shown, or one you did not actually merge, destroys a memory the character should still have.
 
     Return JSON only. No commentary before or after it.
@@ -20,8 +22,9 @@
     {{ render_character_profile("full", actor_uuid) }}
 
     ## Memories To Consider
+    Listed oldest to newest.
     {% for memory in memories %}
-    - **[id {{ memory.id }}]** ({{ memory.type }}{% if memory.emotion %}, {{ memory.emotion }}{% endif %}, importance {{ memory.importance }}{% if memory.game_time %}, {{ memory.game_time }}{% endif %})
+    - **[id {{ memory.id }}]** ({{ memory.type }}{% if memory.emotion %}, {{ memory.emotion }}{% endif %}, importance {{ memory.importance }}{% if memory.game_time %}, {{ memory.game_time }}{% endif %}{% if memory.location %}, at {{ memory.location }}{% endif %})
       {{ memory.content }}{% if length(memory.tags) > 0 %}
       Tags: {% for tag in memory.tags %}{{ tag }}{% if not loop.is_last %}, {% endif %}{% endfor %}{% endif %}
     {% endfor %}
@@ -34,11 +37,12 @@
     ## Instructions
     1. Write each consolidated memory in first person, as {{ actor_name }} recalling it — the same voice the originals are written in.
     2. Merge memories that are redundant, repetitive, or part of one longer story. Leave everything else alone.
-    3. Preserve the load-bearing specifics: names, places, outcomes, amounts, promises, grudges. A consolidation that loses those is worse than the originals it replaced.
-    4. Be dense, not flowery. Two to six sentences each.
-    5. Cite in source_memory_ids ONLY ids that appear in the list above, and only the ones that memory actually consolidates.
-    6. Each id belongs to at most one consolidated memory.
-    7. If nothing in the list merits consolidation, return an empty syntheses array. That is a valid and expected answer — do not invent merges to fill it.
+    3. Reassemble fragments: consecutive entries with adjacent timestamps, the same location, and the same participants are usually slices of one experience — merge them into one memory that tells the whole of it, even when no slice duplicates another.
+    4. Preserve the load-bearing specifics: names, places, outcomes, amounts, promises, grudges. A consolidation that loses those is worse than the originals it replaced.
+    5. Be dense, not flowery. Two to six sentences each.
+    6. Cite in source_memory_ids ONLY ids that appear in the list above, and only the ones that memory actually consolidates.
+    7. Each id belongs to at most one consolidated memory.
+    8. If nothing in the list merits consolidation, return an empty syntheses array. That is a valid and expected answer — do not invent merges to fill it.
 
     ## Response Format
     Respond ONLY with a JSON object:


### PR DESCRIPTION
**Draft** — companion to MinLL/SkyrimNet#1061 (Dreams: on-demand memory consolidation). Merge together; the core PR's `DreamGenerator` renders this template by logical name `memory/dream` and fails the pass with a clear error if it is absent.

Adds `prompts/memory/dream.prompt`: the single prompt for a consolidation pass. House conventions — `[ system ]`/`[ user ]` role markers, `system_head/0010_setting` include, `render_character_profile` for the consolidating character.

What the template enforces, because the C++ side depends on it:

- Every consolidated memory must cite `source_memory_ids` from the presented list only — those ids become provenance, and the cited originals stop surfacing in recall in favor of the synthesis. The core side strips ids outside the input set as hallucinations and drops a synthesis with none left.
- An **empty `syntheses` array is a valid, expected answer** ("nothing worth consolidating") — the model is told not to invent merges to fill it.
- Each id belongs to at most one consolidated memory; consolidations preserve load-bearing specifics (names, places, outcomes, promises, grudges) and stay dense (2–6 sentences).
- A consolidation's `importance_score` should be at least that of its most important source, so syntheses don't decay back below the eligibility floor of the pass that would consolidate them next.
- `tags` are semantic retrieval keywords only — never status labels.

- The template names the fragmentation failure mode explicitly: memories come from time-sliced segments, so one continuous experience often arrives split across consecutive entries — the list is chronological (the core side sorts it), each entry shows its location, and reassembling slices into one memory is an explicit instruction *even when the slices aren't duplicates of each other*.

The optional `instructions` variable carries per-pass guidance from the dashboard modal, the MCP tool, or a trigger's `response.content`.

Exercised by the core PR's `DreamGeneratorTest`, which renders this exact template through `ContextEngine::BuildPayload`.
