### PR TITLE
feat(prompts): gate quest dialogue prompts behind beta25_featureset

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/components/quest_dialogue_action.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/quest_dialogue_action.prompt
@@ -1,6 +1,3 @@
-{# Belt-and-braces gate: this body is only reached through the SpeakQuestLine
-   action description, and that action is not registered when the beta25
-   feature set is off. #}
 {% if feature_enabled("beta25_featureset") %}
 {# Body for the SpeakQuestLine action #}
 {% set quest_lines = available_dialogue(npc.UUID, "quest ids") %}

--- a/SKSE/Plugins/SkyrimNet/prompts/components/quest_dialogue_action.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/quest_dialogue_action.prompt
@@ -1,3 +1,7 @@
+{# Belt-and-braces gate: this body is only reached through the SpeakQuestLine
+   action description, and that action is not registered when the beta25
+   feature set is off. #}
+{% if feature_enabled("beta25_featureset") %}
 {# Body for the SpeakQuestLine action #}
 {% set quest_lines = available_dialogue(npc.UUID, "quest ids") %}
 {% if quest_lines.hasContent %}
@@ -12,4 +16,5 @@ Choosing a line:
 
 Exchanges {{ npc_name }} can trigger now (match one to the conversation, then use its [code]; ### lines are quest headings):
 {{ quest_lines.text }}
+{% endif %}
 {% endif %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0740_quest_dialogue.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0740_quest_dialogue.prompt
@@ -1,8 +1,3 @@
-{# Gated by the beta25 feature set: quest dialogue integration only exists in
-   builds that ship it (SkyrimNet-Core ai_docs/CODE_PATTERNS.md, "Feature flags").
-   feature_enabled() is registered unconditionally by Core and returns false for
-   unknown flag names. It requires a Core build that has the decorator — an
-   unregistered Inja function is a render error, so Core lands first. #}
 {% if feature_enabled("beta25_featureset") %}
 {% if (render_mode == "full" or render_mode == "thoughts" or render_mode == "transform") and not is_player(npc.UUID) %}
 {% set quests = available_dialogue(npc.UUID, "quest") %}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0740_quest_dialogue.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0740_quest_dialogue.prompt
@@ -1,5 +1,5 @@
 {# Gated by the beta25 feature set: quest dialogue integration only exists in
-   builds that ship it (SkyrimNet-Core docs/plans/beta25-featureset-killswitch.md).
+   builds that ship it (SkyrimNet-Core ai_docs/CODE_PATTERNS.md, "Feature flags").
    feature_enabled() is registered unconditionally by Core and returns false for
    unknown flag names. It requires a Core build that has the decorator — an
    unregistered Inja function is a render error, so Core lands first. #}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0740_quest_dialogue.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0740_quest_dialogue.prompt
@@ -1,3 +1,9 @@
+{# Gated by the beta25 feature set: quest dialogue integration only exists in
+   builds that ship it (SkyrimNet-Core docs/plans/beta25-featureset-killswitch.md).
+   feature_enabled() is registered unconditionally by Core and returns false for
+   unknown flag names. It requires a Core build that has the decorator — an
+   unregistered Inja function is a render error, so Core lands first. #}
+{% if feature_enabled("beta25_featureset") %}
 {% if (render_mode == "full" or render_mode == "thoughts" or render_mode == "transform") and not is_player(npc.UUID) %}
 {% set quests = available_dialogue(npc.UUID, "quest") %}
 {% if quests.hasContent %}
@@ -9,5 +15,6 @@ The following are outstanding quests/tasks you are currently seeking help with. 
 
 Quest topics are formatted as a full example dialogue chain, separated by a header:
 {{ quests.text }}
+{% endif %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## Summary

Gates the quest-dialogue prompts from #503 behind the Core `beta25_featureset` kill switch (SkyrimNet-Core PR `feat/beta25-featureset-killswitch`), so beta24 ships without the "Quests You Could Raise" section and the `SpeakQuestLine` body while the files stay on `main` unchanged otherwise. The gate reads the new `feature_enabled("beta25_featureset")` Core decorator, so no divergent GamePlugin branch is needed — `beta25-wip` merges this cleanly and renders it because that Core build has the flag ON.

## Changes

- `prompts/submodules/user_final_instructions/0740_quest_dialogue.prompt` — whole body wrapped in `{% if feature_enabled("beta25_featureset") %} … {% endif %}`
- `prompts/components/quest_dialogue_action.prompt` — same guard as belt-and-braces (it is only reached through the `SpeakQuestLine` action, which Core does not register when the flag is off)

## Landing order

**Merge the Core PR first.** `feature_enabled` is registered unconditionally there; on a Core build without it, the call is an unknown Inja function and the prompt fails to render.

## Testing

- Renders under the Core OFF build's template engine (decorator returns false → empty); Core test suite 1086/1086 with the decorator in place. Not yet verified in-game.
