### PR TITLE
Render carriage occupants as seated in prompts

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/components/context/component_npc_state_summary.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/components/context/component_npc_state_summary.prompt
@@ -20,7 +20,9 @@
             {% set furniture_name = "something" %}
         {% endif %}
         {# Determine appropriate action based on furniture type #}
-        {% if "bed" in furniture_lower or "bedroll" in furniture_lower or "cot" in furniture_lower or "hay pile" in furniture_lower or "fur" in furniture_lower or "animal hide" in furniture_lower or "pelts" in furniture_lower or "sleeping bag" in furniture_lower %}
+        {% if npc.furniture == "Carriage" %}
+            - {{ npc.name }} is seated in a carriage
+        {% else if "bed" in furniture_lower or "bedroll" in furniture_lower or "cot" in furniture_lower or "hay pile" in furniture_lower or "fur" in furniture_lower or "animal hide" in furniture_lower or "pelts" in furniture_lower or "sleeping bag" in furniture_lower %}
             - {{ npc.name }} is lying down in {{ furniture_name }}
         {% else if  "table" in furniture_lower or "desk" in furniture_lower %}
             - {{ npc.name }} is sitting at {{ furniture_name }}

--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0050_physical_activity.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/character_bio/0050_physical_activity.prompt
@@ -18,6 +18,8 @@
         - {{ actor.name }} is currently swimming.
     {% elif sprinting %}
         - {{ actor.name }} is currently sprinting at full speed.
+    {% elif furniture == "Carriage" %}
+        - {{ actor.name }} is currently seated in a carriage.
     {% elif isString(furniture) and length(furniture) > 0 %}
         - {{ actor.name }} is currently using a {{ furniture }}.
     {% elif knockedDown %}


### PR DESCRIPTION
## Paired PR

This PR MUST be released with the paired SkyrimNet core PR.

- **SkyrimNet core:** [MinLL/SkyrimNet#1131](https://github.com/MinLL/SkyrimNet/pull/1131)
- **Paired branch:** `fix/carriage-furniture-detection`

The core PR canonicalizes supported carriage furniture to the exact value `Carriage`. This PR consumes that value in prompt output.

FurnitureName.yaml aliases and compatibility mappings are owned by the core PR; this prompt PR only consumes the resulting canonical value.

## Summary

Render actors using canonical carriage furniture as seated in a carriage instead of using generic furniture wording.

## Changes

### Physical activity

`0050_physical_activity.prompt` renders `{{ actor.name }} is currently seated in a carriage.` when `get_furniture(actorUUID)` returns `Carriage`. The branch precedes generic furniture and walking fallbacks.

### NPC state summary

`component_npc_state_summary.prompt` renders `{{ npc.name }} is seated in a carriage` instead of generic interaction wording or technical furniture marker names.

## Verification

- [x] Both changed prompts pass `validate_prompt`
- [x] Vanilla carriage driver output verified
- [x] Vanilla passenger/player output verified
- [x] Convenient Carriages follower output verified
- [x] Ordinary Bench output remains unchanged
- [x] `CC_CarriageChairMarker` no longer appears in current actor prompt output
- [x] OpenRouter input logs contain canonical carriage wording
- [x] Six-agent staged-diff review: approved, no actionable findings

## Scope

Only these prompt files change:

- `prompts/submodules/character_bio/0050_physical_activity.prompt`
- `prompts/components/context/component_npc_state_summary.prompt`

No changes are REQUIRED for `test_decorators/0700_scene_world_decorators.prompt`, which already exposes raw furniture values. Furniture context in `omnisight/describe_scene.prompt` remains an OPTIONAL future enhancement.

## Limitations

- MQ101's scripted opening cart is outside this furniture-based path.
- Package-name matching and generic vehicle detection are not introduced.
- Transition-time cross-context consistency is tracked separately.
