### PR TITLE
fix(prompts): drop extra endif in quest dialogue final instruction

### DIFF
--- a/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0740_quest_dialogue.prompt
+++ b/SKSE/Plugins/SkyrimNet/prompts/submodules/user_final_instructions/0740_quest_dialogue.prompt
@@ -11,4 +11,3 @@ Quest topics are formatted as a full example dialogue chain, separated by a head
 {{ quests.text }}
 {% endif %}
 {% endif %}
-{% endif %}


### PR DESCRIPTION
`submodules/user_final_instructions/0740_quest_dialogue.prompt` opens two blocks — the `render_mode`/`SpeakQuestLine` gate on line 1 and the `quests.hasContent` check on line 3 — but closed three, leaving an unmatched `{% endif %}` at the end of the file that breaks template rendering.

Removes the stray closer. No other change.

Checked the sibling file added in the same commit, `components/quest_dialogue_action.prompt` — its if/else/endif nesting balances correctly and needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)