### PR TITLE
chore(templates): list Skyrim 1.7.99 / 1.7.104 as an AE option in the bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -105,7 +105,8 @@ body:
       label: Game Version
       options:
         - SE (1.5.97)
-        - AE (1.6.1170+)
+        - AE (1.6.x, up to 1.6.1170)
+        - AE (1.7.99 / 1.7.104)
         - VR
         - GOG
         - Other


### PR DESCRIPTION
## Summary

The bug report's "Game Version" dropdown offered `AE (1.6.1170+)`. Skyrim SE 1.7.99 (2026-08-20) and 1.7.104 (2026-08-27) are the AE builds users are now on, and Core support for them lands with MinLL/SkyrimNet#1222 / MinLL/SkyrimNet#1225. The option is split so reports say which engine line they are on:

- `AE (1.6.x, up to 1.6.1170)`
- `AE (1.7.99 / 1.7.104)`

Tracking: MinLL/SkyrimNet#1222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RYS6dQKQYcjG1y39LjwUn
