### PR TITLE
fix(prompts): close the quest_actions gate in 0740_quest_dialogue again

### DIFF
--- a/plugins/skyrimnet/base/prompts/submodules/user_final_instructions/0740_quest_dialogue.prompt
+++ b/plugins/skyrimnet/base/prompts/submodules/user_final_instructions/0740_quest_dialogue.prompt
@@ -12,3 +12,4 @@ Quest topics are formatted as a full example dialogue chain, separated by a head
 {{ quests.text }}
 {% endif %}
 {% endif %}
+{% endif %}


### PR DESCRIPTION
`0740_quest_dialogue.prompt` on `main` opens three `if`s and closes two, so every dialogue render that pulls the submodule logs `[inja.exception.parser_error] (at 15:1) unmatched if` and the "Quests You Could Raise" section never reaches the model. This restores the closing `{% endif %}`.

How #536's fix was undone:

| when | branch | file | why |
|---|---|---|---|
| 08-26 | zev-quest-integration merge (#531) | 2 if / 3 endif | the merge lost the outer feature gate but kept its endif |
| 08-28 | main, #536 | 2 / 2 | correct for main at the time |
| 08-26 | beta25-wip | 3 / 3 | kept the outer `quest_actions` gate; correct |
| 08-30 | "Merge branch 'main' into beta25-wip" | 3 / 2 | #536's deletion applied cleanly on top of the 3/3 file, no conflict |
| 09-05 | main via #504 | 3 / 2 | beta25-wip merged back |

A sweep of all 1618 `.prompt` files in the base plugin finds no other unbalanced `if`/`endif` or `for`/`endfor` pair, apart from a doc-only `{%- if ... -%}` example in `agent_prompt_helper.prompt`.

Seen in the Core 1.7.104 harness run for MinLL/SkyrimNet#1225 (nine occurrences per L2 run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RYS6dQKQYcjG1y39LjwUn
