### PR TITLE
feat(scripts): skynet_Harness.RoundTrip for the Core engine sweep

### DIFF
--- a/Source/Scripts/skynet_Harness.psc
+++ b/Source/Scripts/skynet_Harness.psc
@@ -1,0 +1,34 @@
+Scriptname skynet_Harness
+{Harness-only probes the SkyrimNet DLL dispatches through its decorator path.
+Nothing in the game calls this script; it is not registered as a decorator.}
+
+; DLL -> Papyrus -> SkyrimNetApi natives -> Papyrus -> DLL.
+; The engine sweep (Core: /harness?api=engine-sweep, ai_docs/ENGINE_SWEEP.md) dispatches this like a
+; decorator and checks for the "ok|" prefix; any other value names the first native that failed.
+String Function RoundTrip(Actor akActor) global
+    If akActor == None
+        Return "fail|no actor"
+    EndIf
+    String uuid = SkyrimNetApi.GetEntityUUID(akActor)
+    If uuid == ""
+        Return "fail|GetEntityUUID"
+    EndIf
+    Actor back = SkyrimNetApi.GetActorByUUID(uuid)
+    If back != akActor
+        Return "fail|GetActorByUUID"
+    EndIf
+    String build = SkyrimNetApi.GetBuildVersion()
+    If build == ""
+        Return "fail|GetBuildVersion"
+    EndIf
+    If !SkyrimNetApi.IsActionRegistered("OpenTrade")
+        Return "fail|IsActionRegistered"
+    EndIf
+    Int queue = SkyrimNetApi.GetSpeechQueueSize()
+    If queue < 0
+        Return "fail|GetSpeechQueueSize"
+    EndIf
+    String result = "ok|" + uuid + "|" + build + "|" + akActor.GetDisplayName() + "|vr=" + (SkyrimNetApi.IsRunningVR() as Int) + "|queue=" + queue
+    Debug.Trace("[SkyrimNet] harness RoundTrip: " + result)
+    Return result
+EndFunction


### PR DESCRIPTION
A global function the DLL dispatches through its decorator path. It calls four `SkyrimNetApi` natives (`GetEntityUUID`, `GetActorByUUID`, `GetBuildVersion`, `IsActionRegistered`, `GetSpeechQueueSize`) and returns `ok|<uuid>|<build>|<name>|vr=<0/1>|queue=<n>` only when every one answered, so the Core engine sweep (`/harness?api=engine-sweep`, MinLL/SkyrimNet PR to follow) can prove Papyrus works in both directions on a new game version. It also writes one `Debug.Trace` line, the positive marker the rig looks for in `Papyrus.0.log`.

Nothing in the game calls it; it is not registered as a decorator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RYS6dQKQYcjG1y39LjwUn
