### PR TITLE
docs: rename the content store to Content Library; build output moves to library/

### DIFF
--- a/.claude/commands/migrate-beta25.md
+++ b/.claude/commands/migrate-beta25.md
@@ -1,11 +1,11 @@
 ---
-description: "Port a Beta 24 loose-file SkyrimNet mod to the Beta 25 content-store layout"
+description: "Port a Beta 24 loose-file SkyrimNet mod to the Beta 25 content-library layout"
 ---
 
 # Migrate to Beta 25
 
 You port a mod author's Beta 24 SkyrimNet content — a loose `config/actions`, `config/triggers`,
-`prompts/**` tree — to the Beta 25 content-store layout, ready to ship as an external layer inside
+`prompts/**` tree — to the Beta 25 content-library layout, ready to ship as an external layer inside
 their mod.
 
 The mechanical transform is **not** yours to perform. `content-convert` applies the naming, path,
@@ -20,7 +20,7 @@ is not in the working tree, read it from the PR.
 ## The tool
 
 `content-convert.exe` is built from the SkyrimNet core repo (`cmake/Tools.cmake`) and ships beside
-the installed plugin. It runs headless — no game, no content store.
+the installed plugin. It runs headless — no game, no content library.
 
 ```
 content-convert <src-tree> <out-dir> --target-version <semver> --manifest <fields.json>

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Guard against records outside the Spriggit tree
         shell: pwsh
         run: |
-          # plugins/SkyrimNet holds only the content-store base tree. Spriggit records belong in
+          # plugins/SkyrimNet holds only the content-library base tree. Spriggit records belong in
           # spriggit/SkyrimNet, the only tree the ESP build converts; anything else here is silently dropped.
           $stray = Get-ChildItem -Path "plugins/SkyrimNet" -Force | Where-Object { $_.Name -ne "base" }
           if ($stray) {

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ CppAPI/
 
 /external/SpriggitCLI-*
 Build_Config_Local.ps1
-# Build output: BuildRelease deploys the assembled content store into the mod dir
-SKSE/Plugins/SkyrimNet/store/
+# Build output: BuildRelease deploys the assembled content library into the mod dir
+SKSE/Plugins/SkyrimNet/library/
 SKSE/Plugins/SkyrimNet/overlay/
 SKSE/Plugins/SkyrimNet/saves/

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ A major focus right now is making SkyrimNet feel approachable for non-technical 
 
 This repository contains the game plugin assets for SkyrimNet:
 - **Spriggit serialized ESP plugin** (`spriggit/SkyrimNet/`) - Text format for version control
-- **Base content store plugin** (`plugins/skyrimnet/base/`) - the `skyrimnet.base` prompt tree SkyrimNet ships (templates, translation CSVs, vanilla/DLC/CC character bios); third-party-mod bios live as `skyrimnet.bios-{mod}` packs on the plugin hub
+- **Base content library plugin** (`plugins/skyrimnet/base/`) - the `skyrimnet.base` prompt tree SkyrimNet ships (templates, translation CSVs, vanilla/DLC/CC character bios); third-party-mod bios live as `skyrimnet.bios-{mod}` packs on the plugin hub
 - **Papyrus script sources** (`Source/Scripts/`) - Script source files
 - **Papyrus headers** (`headers/`) - Vanilla Skyrim script headers for compilation
 - **UI templates** (`interface/`) - MCM and UI configuration
@@ -288,7 +288,7 @@ Compiled files (`.esp` and `.pex`) are NOT stored in this repository. They are g
 
 ```
 ├── spriggit/SkyrimNet/    # Spriggit serialized ESP (version controlled)
-├── plugins/skyrimnet/base/# skyrimnet.base content store plugin (manifest + prompts)
+├── plugins/skyrimnet/base/# skyrimnet.base content library plugin (manifest + prompts)
 ├── Source/Scripts/        # Papyrus source files (.psc)
 ├── Scripts/               # Compiled scripts output (not tracked)
 ├── headers/               # Vanilla Skyrim Papyrus headers

--- a/docs/modding/prompts-and-decorators.md
+++ b/docs/modding/prompts-and-decorators.md
@@ -1,6 +1,6 @@
 # Prompts in Skyrimnet
 
-In SkyrimNet, all prompts are defined in their respective prompt files in the content store (shipped defaults under `store/skyrimnet.base/prompts`, your edits under `overlay/prompts`). This does not only apply to the prompt for getting the npc to speak, but also things like Generating Memories, Prompts for choosing the appropriate action to call as well as prompts added through mods.
+In SkyrimNet, all prompts are defined in their respective prompt files in the content library (shipped defaults under `library/skyrimnet.base/prompts`, your edits under `overlay/prompts`). This does not only apply to the prompt for getting the npc to speak, but also things like Generating Memories, Prompts for choosing the appropriate action to call as well as prompts added through mods.
 
 Likely, the most relevant prompt sub-folders for you to add your files in are `prompts/submodules/character_bio/` and `prompts/submodules/system_head/`
 


### PR DESCRIPTION
GamePlugin half of the Content Library rename (**merge together with MinLL/SkyrimNet#1268**). The layered content system is called the Content Library in the dashboard and release notes; this aligns the docs and the build-output path with that name. On disk the plugin layer folder is now `SKSE/Plugins/SkyrimNet/library/` (was `store/`).

## Changes

- `.gitignore` — build output rule is `SKSE/Plugins/SkyrimNet/library/` (Core's post-build deploys `skyrimnet.base` there now)
- `README.md` — "content library plugin" for the `plugins/skyrimnet/base/` tree
- `docs/modding/prompts-and-decorators.md` — shipped defaults under `library/skyrimnet.base/prompts`, edits under `overlay/prompts`
- `.claude/commands/migrate-beta25.md` — "content-library layout"
- `.github/workflows/validate.yml` — comment only

No prompt, script or ESP changes.

